### PR TITLE
refactor: ErrorCode 인터페이스를 메시지 키 방식으로 변경, 에러 메시지 외부화

### DIFF
--- a/mopl-api/src/main/java/io/mopl/api/common/error/ApiExceptionHandler.java
+++ b/mopl-api/src/main/java/io/mopl/api/common/error/ApiExceptionHandler.java
@@ -25,7 +25,7 @@ public class ApiExceptionHandler {
   @ExceptionHandler(BusinessException.class)
   public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException ex) {
     ErrorCode errorCode = ex.getErrorCode();
-    String resolvedMessage = resolveMessage(errorCode.getMessage());
+    String resolvedMessage = resolveMessage(errorCode.getMessageKey());
     return buildResponse(
         errorCode, errorCode.getClass().getSimpleName(), resolvedMessage, ex.getDetails());
   }
@@ -41,7 +41,7 @@ public class ApiExceptionHandler {
         .getGlobalErrors()
         .forEach(error -> details.put(error.getObjectName(), error.getDefaultMessage()));
 
-    String resolvedMessage = resolveMessage(CommonErrorCode.INVALID_REQUEST.getMessage());
+    String resolvedMessage = resolveMessage(CommonErrorCode.INVALID_REQUEST.getMessageKey());
     return buildResponse(
         CommonErrorCode.INVALID_REQUEST,
         CommonErrorCode.INVALID_REQUEST.name(),
@@ -57,7 +57,7 @@ public class ApiExceptionHandler {
             violation ->
                 details.put(violation.getPropertyPath().toString(), violation.getMessage()));
 
-    String resolvedMessage = resolveMessage(CommonErrorCode.INVALID_REQUEST.getMessage());
+    String resolvedMessage = resolveMessage(CommonErrorCode.INVALID_REQUEST.getMessageKey());
     return buildResponse(
         CommonErrorCode.INVALID_REQUEST,
         CommonErrorCode.INVALID_REQUEST.name(),
@@ -67,7 +67,7 @@ public class ApiExceptionHandler {
 
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ErrorResponse> handleException(Exception ex) {
-    String resolvedMessage = resolveMessage(CommonErrorCode.INTERNAL_SERVER_ERROR.getMessage());
+    String resolvedMessage = resolveMessage(CommonErrorCode.INTERNAL_SERVER_ERROR.getMessageKey());
     return buildResponse(
         CommonErrorCode.INTERNAL_SERVER_ERROR,
         ex.getClass().getSimpleName(),

--- a/mopl-api/src/main/java/io/mopl/api/common/error/AuthErrorCode.java
+++ b/mopl-api/src/main/java/io/mopl/api/common/error/AuthErrorCode.java
@@ -15,7 +15,7 @@ public enum AuthErrorCode implements ErrorCode {
   private final String messageKey;
 
   @Override
-  public String getMessage() {
+  public String getMessageKey() {
     return messageKey;
   }
 }

--- a/mopl-core/src/main/java/io/mopl/core/error/BusinessException.java
+++ b/mopl-core/src/main/java/io/mopl/core/error/BusinessException.java
@@ -10,13 +10,13 @@ public class BusinessException extends RuntimeException {
   private final Map<String, String> details;
 
   public BusinessException(ErrorCode errorCode) {
-    super(errorCode.getMessage());
+    super(errorCode.getMessageKey());
     this.errorCode = errorCode;
     this.details = Map.of();
   }
 
   public BusinessException(ErrorCode errorCode, Map<String, String> details) {
-    super(errorCode.getMessage());
+    super(errorCode.getMessageKey());
     this.errorCode = errorCode;
     this.details = details == null ? Map.of() : Map.copyOf(details);
   }

--- a/mopl-core/src/main/java/io/mopl/core/error/CommonErrorCode.java
+++ b/mopl-core/src/main/java/io/mopl/core/error/CommonErrorCode.java
@@ -6,13 +6,13 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum CommonErrorCode implements ErrorCode {
-  INVALID_REQUEST(400, "잘못된 요청입니다."),
-  UNAUTHORIZED(401, "인증이 필요합니다."),
-  FORBIDDEN(403, "접근 권한이 없습니다."),
-  NOT_FOUND(404, "대상을 찾을 수 없습니다."),
-  CONFLICT(409, "요청이 현재 상태와 충돌합니다."),
-  INTERNAL_SERVER_ERROR(500, "서버 오류가 발생했습니다.");
+  INVALID_REQUEST(400, "error.common.invalid-request"),
+  UNAUTHORIZED(401, "error.common.unauthorized"),
+  FORBIDDEN(403, "error.common.forbidden"),
+  NOT_FOUND(404, "error.common.not-found"),
+  CONFLICT(409, "error.common.conflict"),
+  INTERNAL_SERVER_ERROR(500, "error.common.internal-server-error");
 
   private final int status;
-  private final String message;
+  private final String messageKey;
 }

--- a/mopl-core/src/main/java/io/mopl/core/error/ErrorCode.java
+++ b/mopl-core/src/main/java/io/mopl/core/error/ErrorCode.java
@@ -3,5 +3,5 @@ package io.mopl.core.error;
 public interface ErrorCode {
   int getStatus();
 
-  String getMessage();
+  String getMessageKey();
 }

--- a/mopl-core/src/main/resources/messages.properties
+++ b/mopl-core/src/main/resources/messages.properties
@@ -1,0 +1,7 @@
+# 공통 에러
+error.common.invalid-request=잘못된 요청입니다.
+error.common.unauthorized=인증이 필요합니다.
+error.common.forbidden=접근 권한이 없습니다.
+error.common.not-found=대상을 찾을 수 없습니다.
+error.common.conflict=요청이 현재 상태와 충돌합니다.
+error.common.internal-server-error=서버 오류가 발생했습니다.


### PR DESCRIPTION
## 📌 작업 개요
- 작업 내용: core 모듈의 에러 메시지 외부화
- 관련 이슈: 

## 🚀 주요 변경 사항
- [x] getMessage() -> getMessageKey()로 변경
- [x] CommonErrorCode 메시지 키 적용
- [x] messages.properties 추가

## 🛠 DB 변경 사항
- [ ] MySQL 스키마 변경 여부 (DDL 첨부)
- [ ] Redis 키 구조 변경 여부

## 🧪 테스트 결과 (필수)
> 팀 가이드에 따라 Postman을 이용한 기능 테스트를 완료해야 합니다.

- [ ] **테스트 수행 완료**
- **테스트 시나리오:** (예: 이메일 중복 체크 -> 회원가입 성공 -> 로그인 확인)
- **증빙자료:** (Postman 응답 결과 캡쳐본 첨부 또는 JSON 응답 복사)

## ✅ 체크리스트
- [x] 코드 컨벤션(Checkstyle/Spotless)을 준수했는가?
- [x] 빌드가 성공적으로 수행되는가? (`./gradlew build`)
- [x] 불필요한 주석이나 print문은 제거했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 에러 메시지 처리 시스템을 개선했습니다. 에러 응답 메시지를 더욱 효율적으로 관리하기 위해 메시지 처리 방식을 변경했습니다.
  * 공통 에러 메시지 매핑 파일을 추가하여 에러 메시지 관리를 강화했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->