### PR TITLE
csrf token 조회 기능 구현

### DIFF
--- a/mopl-api/src/main/java/io/mopl/api/auth/controller/AuthController.java
+++ b/mopl-api/src/main/java/io/mopl/api/auth/controller/AuthController.java
@@ -9,9 +9,11 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -56,5 +58,11 @@ public class AuthController {
     cookie.setAttribute("SameSite", "Strict");
 
     response.addCookie(cookie);
+  }
+
+  /** CSRF 토큰 조회 */
+  @GetMapping("/csrf-token")
+  public ResponseEntity<Void> getCsrfToken() {
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 }

--- a/mopl-api/src/main/java/io/mopl/api/auth/jwt/JwtTokenProvider.java
+++ b/mopl-api/src/main/java/io/mopl/api/auth/jwt/JwtTokenProvider.java
@@ -151,7 +151,6 @@ public class JwtTokenProvider {
 
       Date expirationTime = signedJWT.getJWTClaimsSet().getExpirationTime();
       if (expirationTime != null && expirationTime.before(new Date())) {
-        log.error("JWT 토큰 만료");
         return false;
       }
 
@@ -169,7 +168,7 @@ public class JwtTokenProvider {
       String type = claims.getStringClaim("type");
       return "refresh".equals(type);
     } catch (ParseException e) {
-      log.error("Failed to parse token type", e);
+      log.error("토큰 타입 검증에 실패했습니다", e);
       return false;
     }
   }

--- a/mopl-api/src/main/java/io/mopl/api/common/config/SecurityConfig.java
+++ b/mopl-api/src/main/java/io/mopl/api/common/config/SecurityConfig.java
@@ -45,7 +45,8 @@ public class SecurityConfig {
                           String method = request.getMethod();
                           String path = request.getRequestURI();
                           return (method.equals("POST") && path.equals("/api/auth/sign-in"))
-                              || (method.equals("POST") && path.equals("/api/users"));
+                              || (method.equals("POST") && path.equals("/api/users")
+                                  || (method.equals("POST") && path.equals("/api/auth/refresh")));
                         }))
         .sessionManagement(
             session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/mopl-api/src/main/java/io/mopl/api/common/config/SecurityConfig.java
+++ b/mopl-api/src/main/java/io/mopl/api/common/config/SecurityConfig.java
@@ -19,22 +19,6 @@ public class SecurityConfig {
 
   private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
-  // 개발 중 테스트를 위한 csrf 임시 비활성화 메서드
-  //  @Bean
-  //  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-  //    http
-  //        .csrf(csrf -> csrf.disable())
-  //        .sessionManagement(session -> session
-  //            .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-  //        .authorizeHttpRequests(auth -> auth
-  //            .requestMatchers("/api/users/register", "/api/users/login").permitAll()
-  //            .requestMatchers("/api/users/**").authenticated()
-  //            .anyRequest().permitAll())
-  //        .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
-  //
-  //    return http.build();
-  //  }
-
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     http.csrf(

--- a/mopl-api/src/main/java/io/mopl/api/common/config/SecurityConfig.java
+++ b/mopl-api/src/main/java/io/mopl/api/common/config/SecurityConfig.java
@@ -19,6 +19,22 @@ public class SecurityConfig {
 
   private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
+  // 개발 중 테스트를 위한 csrf 비활성화 메서드
+  //  @Bean
+  //  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+  //    http
+  //        .csrf(csrf -> csrf.disable())
+  //        .sessionManagement(session -> session
+  //            .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+  //        .authorizeHttpRequests(auth -> auth
+  //            .requestMatchers("/api/users/register", "/api/users/login").permitAll()
+  //            .requestMatchers("/api/users/**").authenticated()
+  //            .anyRequest().permitAll())
+  //        .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+  //
+  //    return http.build();
+  //  }
+
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     http.csrf(

--- a/mopl-api/src/main/java/io/mopl/api/common/config/SecurityConfig.java
+++ b/mopl-api/src/main/java/io/mopl/api/common/config/SecurityConfig.java
@@ -29,8 +29,8 @@ public class SecurityConfig {
                           String method = request.getMethod();
                           String path = request.getRequestURI();
                           return (method.equals("POST") && path.equals("/api/auth/sign-in"))
-                              || (method.equals("POST") && path.equals("/api/users")
-                                  || (method.equals("POST") && path.equals("/api/auth/refresh")));
+                              || (method.equals("POST") && path.equals("/api/users"))
+                              || (method.equals("POST") && path.equals("/api/auth/refresh"));
                         }))
         .sessionManagement(
             session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))


### PR DESCRIPTION
## 📌 작업 개요
- 작업 내용: CSRF 토큰 조회 API 구현
- 관련 이슈: #이슈번호

## 🚀 주요 변경 사항
- [x] CSRF 토큰 조회 엔드포인트 추가 (GET /api/auth/csrf-token)
- [x] 토큰 재발급 API를 CSRF 검증 제외 대상에 추가
> 이전에 코드래빗이 /api/auth/refresh 는 csrf 검증을 받아야 보안성이 높아진다고 해서 csrf 검증 제외 대상에서 제거했는데, 이걸 제거해두면 
> 프론트엔드 수준에서 새로고침 시 액세스 토큰이 재발급되도록 설정되어 있음
> -> 새로고침 시 refresh 호출
> -> 해당 요청에 x-xsfg-token 헤더 없음
> -> csrf 필터가 해당 요청을 차단, 403 forbidden 발생
> -> 토큰 재발급 실패로 인식, 자동 로그아웃
> 이런 시나리오로 새로고침만 하면 로그아웃이 되어 버리더라고요. 그래서 refresh 도 다시 csrf 검증에서 제외했습니다. 
> 어차피 리프레시 토큰은 HttpOnly 쿠키에 저장되어 있어서 JavaScript로는 접근 불가능하고, 따라서 CSRF 공격으로 토큰을 탈취할 위험도 낮다고 하더라고요. 제외되어 있어도 크게 문제는 없을 것 같습니다. 

- [x] JWT 토큰 만료 에러 로그 제거

## 🛠 DB 변경 사항
- [ ] MySQL 스키마 변경 여부 (DDL 첨부)
- [ ] Redis 키 구조 변경 여부

## 🧪 테스트 결과 (필수)
> 팀 가이드에 따라 Postman/local 환경에서의 기능 테스트를 완료해야 합니다.

- [x] **테스트 수행 완료**
- **테스트 시나리오:**
로그인 성공 -> 액세스 토큰 및 리프레시 토큰 발급
페이지 새로고침 -> 자동으로 토큰 재발급 (로그아웃 되지 않음, 이후 사이트 접속해도 로그인 유지)

- **증빙자료:** (Postman 응답 결과 캡쳐본 첨부 또는 JSON 응답 복사)
<img width="1035" height="297" alt="07  로컬 환경에서 리프레시 토큰 확인" src="https://github.com/user-attachments/assets/03cf5fe4-2769-4bfc-8231-b42428c84eca" />
<img width="1033" height="309" alt="08  리프레시 토큰 재발급" src="https://github.com/user-attachments/assets/05145c23-2c10-439b-b63c-c0070348973b" />

## ✅ 체크리스트
- [x] 코드 컨벤션(Checkstyle/Spotless)을 준수했는가?
- [x] 빌드가 성공적으로 수행되는가? (`./gradlew build`)
- [x] 불필요한 주석이나 print문은 제거했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * CSRF 토큰 조회용 공개 엔드포인트 추가

* **보안 개선**
  * CSRF 토큰 저장 방식을 쿠키 기반으로 구성 변경
  * 사용자 등록 및 토큰 갱신 엔드포인트를 CSRF 보호 예외에 추가

* **품질 개선**
  * 토큰 검증 과정의 불필요한 에러 로그 제거로 로그 가독성 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->