### PR TITLE
feat: Playlist 단건 조회 기능 구현

### DIFF
--- a/mopl-api/src/main/java/io/mopl/api/playlist/controller/PlaylistController.java
+++ b/mopl-api/src/main/java/io/mopl/api/playlist/controller/PlaylistController.java
@@ -31,27 +31,29 @@ public class PlaylistController {
 
   @GetMapping
   public CursorResponsePlaylistDto findPlaylists(
-      @Valid @ModelAttribute PlaylistSearchRequest request, @AuthenticationPrincipal UUID userId) {
+      @Valid @ModelAttribute PlaylistSearchRequest request,
+      @AuthenticationPrincipal(expression = "userId") UUID userId) {
     return playlistQueryService.findPlaylists(request, userId);
   }
 
   @PostMapping
   public ResponseEntity<PlaylistDto> createPlaylist(
-      @Valid @RequestBody PlaylistCreateRequest request, @AuthenticationPrincipal UUID userId) {
+      @Valid @RequestBody PlaylistCreateRequest request,
+      @AuthenticationPrincipal(expression = "userId") UUID userId) {
     PlaylistDto playlistDto = playlistService.create(request, userId);
     return ResponseEntity.status(HttpStatus.CREATED).body(playlistDto);
   }
 
   @PostMapping("/{playlistId}/subscription")
   public ResponseEntity<Void> subscribe(
-      @PathVariable UUID playlistId, @AuthenticationPrincipal UUID userId) {
+      @PathVariable UUID playlistId, @AuthenticationPrincipal(expression = "userId") UUID userId) {
     playlistService.subscribe(playlistId, userId);
     return ResponseEntity.noContent().build();
   }
 
   @DeleteMapping("/{playlistId}/subscription")
   public ResponseEntity<Void> unsubscribe(
-      @PathVariable UUID playlistId, @AuthenticationPrincipal UUID userId) {
+      @PathVariable UUID playlistId, @AuthenticationPrincipal(expression = "userId") UUID userId) {
     playlistService.unsubscribe(playlistId, userId);
     return ResponseEntity.noContent().build();
   }
@@ -60,7 +62,7 @@ public class PlaylistController {
   public ResponseEntity<Void> addContentToPlaylist(
       @PathVariable UUID playlistId,
       @PathVariable UUID contentId,
-      @AuthenticationPrincipal UUID userId) {
+      @AuthenticationPrincipal(expression = "userId") UUID userId) {
     playlistService.addContent(playlistId, contentId, userId);
     return ResponseEntity.noContent().build();
   }
@@ -69,8 +71,15 @@ public class PlaylistController {
   public ResponseEntity<Void> removeContentFromPlaylist(
       @PathVariable UUID playlistId,
       @PathVariable UUID contentId,
-      @AuthenticationPrincipal UUID userId) {
+      @AuthenticationPrincipal(expression = "userId") UUID userId) {
     playlistService.removeContent(playlistId, contentId, userId);
     return ResponseEntity.noContent().build();
+  }
+
+  @GetMapping("/{playlistId}")
+  public ResponseEntity<PlaylistDto> findPlaylist(
+      @PathVariable UUID playlistId, @AuthenticationPrincipal(expression = "userId") UUID userId) {
+    PlaylistDto playlist = playlistQueryService.findPlaylist(playlistId, userId);
+    return ResponseEntity.ok(playlist);
   }
 }

--- a/mopl-api/src/main/java/io/mopl/api/playlist/service/PlaylistQueryService.java
+++ b/mopl-api/src/main/java/io/mopl/api/playlist/service/PlaylistQueryService.java
@@ -2,15 +2,21 @@ package io.mopl.api.playlist.service;
 
 import io.mopl.api.content.dto.ContentSummary;
 import io.mopl.api.playlist.domain.Playlist;
+import io.mopl.api.playlist.domain.PlaylistSubscriptionId;
 import io.mopl.api.playlist.dto.CursorResponsePlaylistDto;
 import io.mopl.api.playlist.dto.PlaylistDto;
 import io.mopl.api.playlist.dto.PlaylistPage;
 import io.mopl.api.playlist.dto.PlaylistSearchRequest;
 import io.mopl.api.playlist.repository.PlaylistQueryRepository;
+import io.mopl.api.playlist.repository.PlaylistRepository;
+import io.mopl.api.playlist.repository.PlaylistSubscriptionRepository;
 import io.mopl.api.playlist.service.loader.PlaylistContentLoader;
 import io.mopl.api.playlist.service.loader.PlaylistOwnerLoader;
 import io.mopl.api.playlist.service.loader.PlaylistSubscriptionLoader;
 import io.mopl.api.user.dto.UserSummary;
+import io.mopl.api.user.service.UserService;
+import io.mopl.core.error.BusinessException;
+import io.mopl.core.error.CommonErrorCode;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -30,7 +36,11 @@ public class PlaylistQueryService {
   private final PlaylistOwnerLoader playlistOwnerLoader;
   private final PlaylistSubscriptionLoader playlistSubscriptionLoader;
   private final PlaylistContentLoader playlistContentLoader;
+  private final PlaylistSubscriptionRepository playlistSubscriptionRepository;
+  private final PlaylistRepository playlistRepository;
+  private final UserService userService;
 
+  // Playlist 조회
   public CursorResponsePlaylistDto findPlaylists(PlaylistSearchRequest request, UUID me) {
 
     // 1) 파라미터 기본값/안전장치
@@ -110,6 +120,35 @@ public class PlaylistQueryService {
         .totalCount(totalCount)
         .sortBy(sortBy)
         .sortDirection(sortDirection)
+        .build();
+  }
+
+  // playlist 단건 조회
+  public PlaylistDto findPlaylist(UUID playlistId, UUID me) {
+    Playlist playlist =
+        playlistRepository
+            .findById(playlistId)
+            .orElseThrow(() -> new BusinessException(CommonErrorCode.NOT_FOUND));
+
+    UserSummary owner = userService.getUserSummary(playlist.getOwnerId());
+
+    boolean subscribedByMe = false;
+    if (me != null) {
+      PlaylistSubscriptionId id = new PlaylistSubscriptionId(playlistId, me);
+      subscribedByMe = playlistSubscriptionRepository.existsById(id);
+    }
+
+    List<ContentSummary> contents = playlistContentLoader.loadContentsByPlaylistId(playlistId);
+
+    return PlaylistDto.builder()
+        .id(playlistId)
+        .owner(owner)
+        .title(playlist.getTitle())
+        .description(playlist.getDescription())
+        .updatedAt(playlist.getUpdatedAt())
+        .subscriberCount(playlist.getSubscriberCount())
+        .subscribedByMe(subscribedByMe)
+        .contents(contents)
         .build();
   }
 }

--- a/mopl-api/src/main/java/io/mopl/api/playlist/service/loader/PlaylistContentLoader.java
+++ b/mopl-api/src/main/java/io/mopl/api/playlist/service/loader/PlaylistContentLoader.java
@@ -185,4 +185,14 @@ public class PlaylistContentLoader {
       String thumbnailUrl,
       double averageRating,
       int reviewCount) {}
+
+  // 6. 단건 조회 (위에 코드는 전체조회)
+  public List<ContentSummary> loadContentsByPlaylistId(UUID playlistId) {
+    if (playlistId == null) {
+      return List.of();
+    }
+    Map<UUID, List<ContentSummary>> map = loadContentsByPlaylistIds(List.of(playlistId));
+    List<ContentSummary> contents = map.get(playlistId);
+    return contents != null ? contents : List.of();
+  }
 }


### PR DESCRIPTION
## 📌 작업 개요
- 작업 내용: Playlist 단건 조회 기능 구현
- 관련 이슈: 없음

## 🚀 주요 변경 사항
- Controller에서 기존 @AuthenticationPrincipal UUID userId에서 @AuthenticationPrincipal(expression = "userId") UUID userId 으로 변경하여 AuthUser에서  userId값을 꺼내서 UUID Type으로 변경하였습니다.

## 🛠 DB 변경 사항
- 없음

## 🧪 테스트 결과 (필수)
<img width="1258" height="967" alt="단건 조회 테스트 Postman" src="https://github.com/user-attachments/assets/61a4c709-297b-4cbe-bbb2-3b425fab9a3c" />
<img width="1681" height="605" alt="Playlist 단건 조회 로컬" src="https://github.com/user-attachments/assets/b58bffb7-41a1-418c-8e93-032aeda116b6" />


- [x] **테스트 수행 완료**
- **테스트 시나리오:** (로그인 -> Playlist 생성 -> PlaylistId를 이용한 단건 조회)
- **증빙자료:** (Postman 응답 결과 캡쳐본 첨부 또는 JSON 응답 복사)

## ✅ 체크리스트
- [x] 코드 컨벤션(Checkstyle/Spotless)을 준수했는가?
- [x] 빌드가 성공적으로 수행되는가? (`./gradlew build`)
- [x] 불필요한 주석이나 print문은 제거했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 특정 플레이리스트를 조회하는 새로운 엔드포인트 추가. 인증된 사용자는 이제 플레이리스트 ID를 통해 개별 플레이리스트를 요청하고 상세 정보, 소유자 정보, 구독 상태, 콘텐츠 목록을 포함한 전체 플레이리스트 데이터를 받을 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->