### PR TITLE
refactor: 콘텐츠 추가 nativeQuery 적용

### DIFF
--- a/mopl-api/src/main/java/io/mopl/api/playlist/repository/PlaylistContentRepository.java
+++ b/mopl-api/src/main/java/io/mopl/api/playlist/repository/PlaylistContentRepository.java
@@ -20,7 +20,7 @@ public interface PlaylistContentRepository
               + "values (:playlistId, :contentId) "
               + "on duplicate key update playlist_id = playlist_id",
       nativeQuery = true)
-  int insertIgnore(@Param("playlistId") UUID playlistId, @Param("contentId") UUID contentId);
+  int insertIgnore(@Param("playlistId") String playlistId, @Param("contentId") String contentId);
 
   @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query("delete from PlaylistContent pc where pc.id.contentId = :contentId")

--- a/mopl-api/src/main/java/io/mopl/api/playlist/service/PlaylistService.java
+++ b/mopl-api/src/main/java/io/mopl/api/playlist/service/PlaylistService.java
@@ -125,7 +125,8 @@ public class PlaylistService {
       throw new BusinessException(ContentErrorCode.CONTENT_NOT_FOUND);
     }
 
-    int affected = playlistContentRepository.insertIgnore(playlistId, contentId);
+    int affected =
+        playlistContentRepository.insertIgnore(playlistId.toString(), contentId.toString());
     if (affected == 0) {
       log.debug(
           "playlist_content_already_exists playlistId={} contentId={}", playlistId, contentId);


### PR DESCRIPTION
## 📌 작업 개요
- 작업 내용: 콘텐츠 추가시 nativeQuery를 사용하기 위해 playlistId, contentId UUID -> String으로 타입 변경
- 관련 이슈: 없음

## 🚀 주요 변경 사항
- 콘텐츠 추가시 nativeQuery를 사용하기 위해 playlistId, contentId UUID -> String으로 타입 변경하여 MySQL 전용 Upsert 적용
- MySQL 전용 Upsert 적용하여 플레이리스트에 콘텐츠 추가시 중복을 추가 코드 없이 안전하게 잡아줍니다.

## 🛠 DB 변경 사항
- 없음

## 🧪 테스트 결과 (필수)
<img width="1609" height="752" alt="플레이리스트 콘텐츠 추가 테스트 로컬" src="https://github.com/user-attachments/assets/c566a869-4984-484b-9284-74cadca586cf" />

- [x] **테스트 수행 완료**
- **테스트 시나리오:** 플레이리스트에  콘텐츠 추가하기 및 콘텐츠 조회할 때 플레이리스트에 추가 버튼을 눌러 추가해도 플레이리스트 생성과 콘텐츠 추가가 같이 되는 것을 확인했습니다.

## ✅ 체크리스트
- [x] 코드 컨벤션(Checkstyle/Spotless)을 준수했는가?
- [x] 빌드가 성공적으로 수행되는가? (`./gradlew build`)
- [x] 불필요한 주석이나 print문은 제거했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 플레이리스트 콘텐츠 처리 시스템 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->