### PR TITLE
유저 프로필 변경 API 구현

### DIFF
--- a/mopl-api/build.gradle
+++ b/mopl-api/build.gradle
@@ -43,4 +43,8 @@ dependencies {
     // 재시도 메커니즘
     implementation 'org.springframework.retry:spring-retry:2.0.5'
     implementation 'org.springframework:spring-aspects'
+
+    // AWS S3 SDK
+    implementation platform('software.amazon.awssdk:bom:2.41.1')
+    implementation 'software.amazon.awssdk:s3:2.40.17'
 }

--- a/mopl-api/build.gradle
+++ b/mopl-api/build.gradle
@@ -46,5 +46,5 @@ dependencies {
 
     // AWS S3 SDK
     implementation platform('software.amazon.awssdk:bom:2.41.1')
-    implementation 'software.amazon.awssdk:s3:2.40.17'
+    implementation 'software.amazon.awssdk:s3'
 }

--- a/mopl-api/src/main/java/io/mopl/api/auth/controller/AuthController.java
+++ b/mopl-api/src/main/java/io/mopl/api/auth/controller/AuthController.java
@@ -66,7 +66,7 @@ public class AuthController {
 
   /** 리프레시 토큰 쿠키 제거 */
   private void clearRefreshTokenCookie(HttpServletResponse response) {
-    Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, null);
+    Cookie cookie = new Cookie(cookieSecurityProperties.getRefreshToken().getName(), null);
     cookie.setHttpOnly(true);
     cookie.setSecure(cookieSecurityProperties.isSecure());
     cookie.setPath("/api/auth");
@@ -88,7 +88,7 @@ public class AuthController {
 
   /** 리프레시 토큰 쿠키 설정 */
   private void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
-    Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, refreshToken);
+    Cookie cookie = new Cookie(cookieSecurityProperties.getRefreshToken().getName(), refreshToken);
     cookie.setHttpOnly(true);
     cookie.setSecure(cookieSecurityProperties.isSecure());
     cookie.setPath("/api/auth");

--- a/mopl-api/src/main/java/io/mopl/api/auth/controller/AuthController.java
+++ b/mopl-api/src/main/java/io/mopl/api/auth/controller/AuthController.java
@@ -98,9 +98,8 @@ public class AuthController {
 
   /** CSRF 토큰 조회 */
   @GetMapping("/csrf-token")
-  public ResponseEntity<Void> getCsrfToken(CsrfToken csrfToken) {
-    csrfToken.getToken();
-    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+  public ResponseEntity<Void> csrf(CsrfToken csrfToken) {
+    return ResponseEntity.noContent().build();
   }
 
   /** 비밀번호 초기화 후 이메일 전송 */

--- a/mopl-api/src/main/java/io/mopl/api/auth/controller/AuthController.java
+++ b/mopl-api/src/main/java/io/mopl/api/auth/controller/AuthController.java
@@ -7,6 +7,7 @@ import io.mopl.api.auth.dto.SignInRequest;
 import io.mopl.api.auth.jwt.JwtTokenProvider;
 import io.mopl.api.auth.service.AuthService;
 import io.mopl.api.auth.service.RefreshTokenService;
+import io.mopl.api.common.config.CookieSecurityProperties;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -32,6 +33,7 @@ public class AuthController {
   private final AuthService authService;
   private final JwtTokenProvider jwtTokenProvider;
   private final RefreshTokenService refreshTokenService;
+  private final CookieSecurityProperties cookieSecurityProperties;
 
   private static final String REFRESH_TOKEN_COOKIE_NAME = "REFRESH_TOKEN";
 
@@ -66,10 +68,10 @@ public class AuthController {
   private void clearRefreshTokenCookie(HttpServletResponse response) {
     Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, null);
     cookie.setHttpOnly(true);
-    cookie.setSecure(false); // TODO: production 환경에서는 true
+    cookie.setSecure(cookieSecurityProperties.isSecure());
     cookie.setPath("/api/auth");
     cookie.setMaxAge(0);
-    cookie.setAttribute("SameSite", "Strict");
+    cookie.setAttribute("SameSite", cookieSecurityProperties.getSameSite());
 
     response.addCookie(cookie);
   }
@@ -88,10 +90,10 @@ public class AuthController {
   private void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
     Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, refreshToken);
     cookie.setHttpOnly(true);
-    cookie.setSecure(false); // TODO: production 환경에서는 true
+    cookie.setSecure(cookieSecurityProperties.isSecure());
     cookie.setPath("/api/auth");
     cookie.setMaxAge((int) jwtTokenProvider.getRefreshTokenValidityInSeconds());
-    cookie.setAttribute("SameSite", "Strict");
+    cookie.setAttribute("SameSite", cookieSecurityProperties.getSameSite());
 
     response.addCookie(cookie);
   }

--- a/mopl-api/src/main/java/io/mopl/api/auth/controller/AuthController.java
+++ b/mopl-api/src/main/java/io/mopl/api/auth/controller/AuthController.java
@@ -35,6 +35,7 @@ public class AuthController {
   private final RefreshTokenService refreshTokenService;
   private final CookieSecurityProperties cookieSecurityProperties;
 
+  // 주의: 이 상수값은 application.yml의 REFRESH_TOKEN_NAME 기본값과 일치해야 함
   private static final String REFRESH_TOKEN_COOKIE_NAME = "REFRESH_TOKEN";
 
   /** 로그인 Content-Type: application/x-www-form-urlencoded */

--- a/mopl-api/src/main/java/io/mopl/api/auth/controller/SpaController.java
+++ b/mopl-api/src/main/java/io/mopl/api/auth/controller/SpaController.java
@@ -1,0 +1,19 @@
+package io.mopl.api.auth.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class SpaController {
+
+  @GetMapping({
+    "/profiles/**",
+    "/playlists/**",
+    "/contents/**",
+    "/conversations/**",
+    "/notifications/**"
+  })
+  public String forward() {
+    return "forward:/index.html";
+  }
+}

--- a/mopl-api/src/main/java/io/mopl/api/common/config/CookieSecurityProperties.java
+++ b/mopl-api/src/main/java/io/mopl/api/common/config/CookieSecurityProperties.java
@@ -13,10 +13,10 @@ import org.springframework.stereotype.Component;
 public class CookieSecurityProperties {
 
   /** HTTPS에서만 쿠키 전송 여부 (프로덕션: true, 개발: false) */
-  private boolean secure = false;
+  private boolean secure;
 
   /** SameSite 속성 (Strict, Lax, None) */
-  private String sameSite = "Lax";
+  private String sameSite;
 
   /** CSRF 토큰 쿠키 설정 */
   private CsrfCookie csrf = new CsrfCookie();
@@ -27,15 +27,15 @@ public class CookieSecurityProperties {
   @Getter
   @Setter
   public static class CsrfCookie {
-    private String name = "XSRF-TOKEN";
-    private boolean httpOnly = false;
+    private String name;
+    private boolean httpOnly;
   }
 
   @Getter
   @Setter
   public static class RefreshTokenCookie {
-    private String name = "REFRESH_TOKEN";
-    private boolean httpOnly = true;
-    private int maxAge = 604800; // 7일
+    private String name;
+    private boolean httpOnly;
+    private int maxAge;
   }
 }

--- a/mopl-api/src/main/java/io/mopl/api/common/config/CookieSecurityProperties.java
+++ b/mopl-api/src/main/java/io/mopl/api/common/config/CookieSecurityProperties.java
@@ -1,0 +1,41 @@
+package io.mopl.api.common.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/** application.yml의 security.cookie 설정을 읽어오는 클래스 */
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "security.cookie")
+public class CookieSecurityProperties {
+
+  /** HTTPS에서만 쿠키 전송 여부 (프로덕션: true, 개발: false) */
+  private boolean secure = false;
+
+  /** SameSite 속성 (Strict, Lax, None) */
+  private String sameSite = "Lax";
+
+  /** CSRF 토큰 쿠키 설정 */
+  private CsrfCookie csrf = new CsrfCookie();
+
+  /** Refresh 토큰 쿠키 설정 */
+  private RefreshTokenCookie refreshToken = new RefreshTokenCookie();
+
+  @Getter
+  @Setter
+  public static class CsrfCookie {
+    private String name = "XSRF-TOKEN";
+    private boolean httpOnly = false;
+  }
+
+  @Getter
+  @Setter
+  public static class RefreshTokenCookie {
+    private String name = "REFRESH_TOKEN";
+    private boolean httpOnly = true;
+    private int maxAge = 604800; // 7일
+  }
+}

--- a/mopl-api/src/main/java/io/mopl/api/common/config/CsrfCookieFilter.java
+++ b/mopl-api/src/main/java/io/mopl/api/common/config/CsrfCookieFilter.java
@@ -8,6 +8,7 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.stereotype.Component;
@@ -16,7 +17,10 @@ import org.springframework.web.filter.GenericFilterBean;
 /** CSRF 토큰 쿠키 생성 필터 */
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class CsrfCookieFilter extends GenericFilterBean {
+
+  private final CookieSecurityProperties cookieSecurityProperties;
 
   private static final String CSRF_COOKIE_NAME = "XSRF-TOKEN";
 
@@ -34,13 +38,16 @@ public class CsrfCookieFilter extends GenericFilterBean {
 
       Cookie cookie = new Cookie(CSRF_COOKIE_NAME, token);
       cookie.setPath("/");
-      cookie.setHttpOnly(false);
-      cookie.setSecure(false); // TODO: Production에서는 true
+      cookie.setHttpOnly(cookieSecurityProperties.getCsrf().isHttpOnly());
+      cookie.setSecure(cookieSecurityProperties.isSecure());
       cookie.setMaxAge(-1);
-      cookie.setAttribute("SameSite", "Lax");
+      cookie.setAttribute("SameSite", cookieSecurityProperties.getSameSite());
 
       httpResponse.addCookie(cookie);
-      log.debug("CSRF 쿠키 설정: {}", token.substring(0, Math.min(10, token.length())) + "...");
+      log.debug(
+          "CSRF 쿠키 설정: secure={}, sameSite={}",
+          cookieSecurityProperties.isSecure(),
+          cookieSecurityProperties.getSameSite());
     }
 
     chain.doFilter(request, response);

--- a/mopl-api/src/main/java/io/mopl/api/common/config/CsrfCookieFilter.java
+++ b/mopl-api/src/main/java/io/mopl/api/common/config/CsrfCookieFilter.java
@@ -36,7 +36,7 @@ public class CsrfCookieFilter extends GenericFilterBean {
     if (csrfToken != null) {
       String token = csrfToken.getToken();
 
-      Cookie cookie = new Cookie(CSRF_COOKIE_NAME, token);
+      Cookie cookie = new Cookie(cookieSecurityProperties.getCsrf().getName(), token);
       cookie.setPath("/");
       cookie.setHttpOnly(cookieSecurityProperties.getCsrf().isHttpOnly());
       cookie.setSecure(cookieSecurityProperties.isSecure());

--- a/mopl-api/src/main/java/io/mopl/api/common/config/CsrfCookieFilter.java
+++ b/mopl-api/src/main/java/io/mopl/api/common/config/CsrfCookieFilter.java
@@ -37,6 +37,7 @@ public class CsrfCookieFilter extends GenericFilterBean {
       cookie.setHttpOnly(false);
       cookie.setSecure(false); // TODO: Production에서는 true
       cookie.setMaxAge(-1);
+      cookie.setAttribute("SameSite", "Lax");
 
       httpResponse.addCookie(cookie);
       log.debug("CSRF 쿠키 설정: {}", token.substring(0, Math.min(10, token.length())) + "...");

--- a/mopl-api/src/main/java/io/mopl/api/common/config/CsrfCookieFilter.java
+++ b/mopl-api/src/main/java/io/mopl/api/common/config/CsrfCookieFilter.java
@@ -2,27 +2,46 @@ package io.mopl.api.common.config;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.stereotype.Component;
-import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.filter.GenericFilterBean;
 
-/** CSRF 토큰 쿠키 자동 생성 필터 */
+/** CSRF 토큰 쿠키 생성 필터 */
+@Slf4j
 @Component
-public class CsrfCookieFilter extends OncePerRequestFilter {
+public class CsrfCookieFilter extends GenericFilterBean {
+
+  private static final String CSRF_COOKIE_NAME = "XSRF-TOKEN";
 
   @Override
-  protected void doFilterInternal(
-      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
-      throws ServletException, IOException {
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+      throws IOException, ServletException {
 
-    CsrfToken csrfToken = (CsrfToken) request.getAttribute(CsrfToken.class.getName());
+    HttpServletRequest httpRequest = (HttpServletRequest) request;
+    HttpServletResponse httpResponse = (HttpServletResponse) response;
+
+    CsrfToken csrfToken = (CsrfToken) httpRequest.getAttribute(CsrfToken.class.getName());
+
     if (csrfToken != null) {
-      csrfToken.getToken();
+      String token = csrfToken.getToken();
+
+      Cookie cookie = new Cookie(CSRF_COOKIE_NAME, token);
+      cookie.setPath("/");
+      cookie.setHttpOnly(false);
+      cookie.setSecure(false); // TODO: Production에서는 true
+      cookie.setMaxAge(-1);
+
+      httpResponse.addCookie(cookie);
+      log.debug("CSRF 쿠키 설정: {}", token.substring(0, Math.min(10, token.length())) + "...");
     }
 
-    filterChain.doFilter(request, response);
+    chain.doFilter(request, response);
   }
 }

--- a/mopl-api/src/main/java/io/mopl/api/common/config/CsrfCookieFilter.java
+++ b/mopl-api/src/main/java/io/mopl/api/common/config/CsrfCookieFilter.java
@@ -22,8 +22,6 @@ public class CsrfCookieFilter extends GenericFilterBean {
 
   private final CookieSecurityProperties cookieSecurityProperties;
 
-  private static final String CSRF_COOKIE_NAME = "XSRF-TOKEN";
-
   @Override
   public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
       throws IOException, ServletException {

--- a/mopl-api/src/main/java/io/mopl/api/common/config/S3Config.java
+++ b/mopl-api/src/main/java/io/mopl/api/common/config/S3Config.java
@@ -4,36 +4,34 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
 
 @Configuration
 @RequiredArgsConstructor
 public class S3Config {
 
-  private final S3properties s3properties;
+  private final S3Properties s3properties;
 
   @Bean
   public S3Client s3Client() {
-    return S3Client.builder()
-        .region(Region.of(s3properties.getRegion()))
-        .credentialsProvider(
-            StaticCredentialsProvider.create(
-                AwsBasicCredentials.create(
-                    s3properties.getAccessKey(), s3properties.getSecretKey())))
-        .build();
+    S3ClientBuilder builder = S3Client.builder().region(Region.of(s3properties.getRegion()));
+
+    if (hasText(s3properties.getAccessKey()) && hasText(s3properties.getSecretKey())) {
+      AwsBasicCredentials credentials =
+          AwsBasicCredentials.create(s3properties.getAccessKey(), s3properties.getSecretKey());
+      builder.credentialsProvider(StaticCredentialsProvider.create(credentials));
+    } else {
+      builder.credentialsProvider(DefaultCredentialsProvider.builder().build());
+    }
+
+    return builder.build();
   }
 
-  @Bean
-  public S3Presigner s3Presigner() {
-    return S3Presigner.builder()
-        .region(Region.of(s3properties.getRegion()))
-        .credentialsProvider(
-            StaticCredentialsProvider.create(
-                AwsBasicCredentials.create(
-                    s3properties.getAccessKey(), s3properties.getSecretKey())))
-        .build();
+  private static boolean hasText(String value) {
+    return value != null && !value.isBlank();
   }
 }

--- a/mopl-api/src/main/java/io/mopl/api/common/config/S3Config.java
+++ b/mopl-api/src/main/java/io/mopl/api/common/config/S3Config.java
@@ -1,0 +1,39 @@
+package io.mopl.api.common.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+@RequiredArgsConstructor
+public class S3Config {
+
+  private final S3properties s3properties;
+
+  @Bean
+  public S3Client s3Client() {
+    return S3Client.builder()
+        .region(Region.of(s3properties.getRegion()))
+        .credentialsProvider(
+            StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(
+                    s3properties.getAccessKey(), s3properties.getSecretKey())))
+        .build();
+  }
+
+  @Bean
+  public S3Presigner s3Presigner() {
+    return S3Presigner.builder()
+        .region(Region.of(s3properties.getRegion()))
+        .credentialsProvider(
+            StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(
+                    s3properties.getAccessKey(), s3properties.getSecretKey())))
+        .build();
+  }
+}

--- a/mopl-api/src/main/java/io/mopl/api/common/config/S3Properties.java
+++ b/mopl-api/src/main/java/io/mopl/api/common/config/S3Properties.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 @Setter
 @Component
 @ConfigurationProperties(prefix = "aws.s3")
-public class S3properties {
+public class S3Properties {
 
   private String accessKey;
   private String secretKey;

--- a/mopl-api/src/main/java/io/mopl/api/common/config/S3properties.java
+++ b/mopl-api/src/main/java/io/mopl/api/common/config/S3properties.java
@@ -1,0 +1,19 @@
+package io.mopl.api.common.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "aws.s3")
+public class S3properties {
+
+  private String accessKey;
+  private String secretKey;
+  private String region;
+  private String bucket;
+  private String profileImagePath = "profiles/";
+}

--- a/mopl-api/src/main/java/io/mopl/api/common/config/SecurityConfig.java
+++ b/mopl-api/src/main/java/io/mopl/api/common/config/SecurityConfig.java
@@ -81,6 +81,19 @@ public class SecurityConfig {
                     .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**")
                     .permitAll()
 
+                    /* ========== SPA 프론트엔드 라우트 ========== */
+                    .requestMatchers(
+                        "/profiles/**",
+                        "/playlists/**",
+                        "/contents/**",
+                        "/conversations/**",
+                        "/notifications/**")
+                    .permitAll()
+
+                    /* ========== CSRF 토큰 발급 ========== */
+                    .requestMatchers(HttpMethod.GET, "/api/csrf")
+                    .permitAll()
+
                     /* ========== 인증 관리 ========== */
                     // 전체: 모든 기능
                     .requestMatchers("/api/auth/**")

--- a/mopl-api/src/main/java/io/mopl/api/common/config/SecurityConfig.java
+++ b/mopl-api/src/main/java/io/mopl/api/common/config/SecurityConfig.java
@@ -21,6 +21,7 @@ public class SecurityConfig {
 
   private final JwtAuthenticationFilter jwtAuthenticationFilter;
   private final CsrfCookieFilter csrfCookieFilter;
+  private final CookieSecurityProperties cookieSecurityProperties;
 
   // 개발 중 테스트를 위한 csrf 비활성화 메서드
   //  @Bean
@@ -42,9 +43,10 @@ public class SecurityConfig {
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
     CookieCsrfTokenRepository csrfTokenRepository = CookieCsrfTokenRepository.withHttpOnlyFalse();
+
+    csrfTokenRepository.setCookieName(cookieSecurityProperties.getCsrf().getName());
     csrfTokenRepository.setHeaderName("X-XSRF-TOKEN");
 
-    // Plain CSRF Token Handler 사용 (XOR 인코딩 비활성화)
     CsrfTokenRequestAttributeHandler requestHandler = new CsrfTokenRequestAttributeHandler();
     requestHandler.setCsrfRequestAttributeName("_csrf");
 

--- a/mopl-api/src/main/java/io/mopl/api/common/config/SecurityConfig.java
+++ b/mopl-api/src/main/java/io/mopl/api/common/config/SecurityConfig.java
@@ -91,7 +91,7 @@ public class SecurityConfig {
                     .permitAll()
 
                     /* ========== CSRF 토큰 발급 ========== */
-                    .requestMatchers(HttpMethod.GET, "/api/csrf")
+                    .requestMatchers(HttpMethod.GET, "/api/auth/csrf-token")
                     .permitAll()
 
                     /* ========== 인증 관리 ========== */

--- a/mopl-api/src/main/java/io/mopl/api/user/controller/UserController.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/controller/UserController.java
@@ -4,6 +4,7 @@ import io.mopl.api.common.config.AuthUser;
 import io.mopl.api.user.dto.ChangePasswordRequest;
 import io.mopl.api.user.dto.UserCreateRequest;
 import io.mopl.api.user.dto.UserDto;
+import io.mopl.api.user.dto.UserUpdateRequest;
 import io.mopl.api.user.service.UserService;
 import io.mopl.core.error.BusinessException;
 import io.mopl.core.error.CommonErrorCode;
@@ -12,6 +13,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,7 +22,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @RestController
@@ -57,5 +61,21 @@ public class UserController {
 
     userService.changePassword(userId, request);
     return ResponseEntity.noContent().build();
+  }
+
+  /** 프로필 변경 */
+  @PatchMapping(value = "/{userId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ResponseEntity<UserDto> updateProfile(
+      @PathVariable UUID userId,
+      @RequestPart("request") @Valid UserUpdateRequest request,
+      @RequestPart(value = "image", required = false) MultipartFile profileImage,
+      @AuthenticationPrincipal AuthUser authUser) {
+
+    if (!userId.equals(authUser.getUserId())) {
+      throw new BusinessException(CommonErrorCode.FORBIDDEN);
+    }
+
+    UserDto response = userService.updateProfile(userId, request, profileImage);
+    return ResponseEntity.ok(response);
   }
 }

--- a/mopl-api/src/main/java/io/mopl/api/user/domain/User.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/domain/User.java
@@ -40,6 +40,7 @@ public class User {
   @Column(nullable = false, unique = true)
   private String email;
 
+  @Setter
   @Column(length = 100)
   private String name;
 
@@ -63,11 +64,12 @@ public class User {
   @Builder.Default
   private boolean locked = false;
 
+  @Setter
   @Column(name = "profile_image_url", length = 2048)
   private String profileImageUrl;
 
-  @Column(name = "temp_password_hash", length = 255)
   @Setter
+  @Column(name = "temp_password_hash", length = 255)
   private String tempPasswordHash;
 
   @Setter

--- a/mopl-api/src/main/java/io/mopl/api/user/service/ProfileImageUploadService.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/service/ProfileImageUploadService.java
@@ -14,7 +14,6 @@ import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
-import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
 
@@ -42,7 +41,6 @@ public class ProfileImageUploadService {
               .bucket(s3Properties.getBucket())
               .key(key)
               .contentType(file.getContentType())
-              .acl(ObjectCannedACL.PUBLIC_READ)
               .serverSideEncryption(ServerSideEncryption.AES256)
               .build();
 

--- a/mopl-api/src/main/java/io/mopl/api/user/service/ProfileImageUploadService.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/service/ProfileImageUploadService.java
@@ -82,8 +82,18 @@ public class ProfileImageUploadService {
 
   /** 허용된 확장자인지 확인 */
   private boolean isAllowedExtension(String originalFilename) {
-    String extension =
-        originalFilename.substring(originalFilename.lastIndexOf(".") + 1).toLowerCase();
+
+    if (originalFilename == null || originalFilename.isBlank()) {
+      return false;
+    }
+
+    int dotIndex = originalFilename.lastIndexOf('.');
+
+    if (dotIndex == -1 || dotIndex == originalFilename.length() - 1) {
+      return false;
+    }
+
+    String extension = originalFilename.substring(dotIndex + 1).toLowerCase();
     return ALLOWED_EXTENSIONS.contains(extension);
   }
 

--- a/mopl-api/src/main/java/io/mopl/api/user/service/ProfileImageUploadService.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/service/ProfileImageUploadService.java
@@ -1,0 +1,125 @@
+package io.mopl.api.user.service;
+
+import io.mopl.api.common.config.S3Properties;
+import io.mopl.core.error.BusinessException;
+import io.mopl.core.error.CommonErrorCode;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProfileImageUploadService {
+
+  private final S3Client s3Client;
+  private final S3Properties s3Properties;
+
+  private static final List<String> ALLOWED_EXTENSIONS = Arrays.asList("jpg", "jpeg", "png");
+  private static final long MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+
+  /** 프로필 이미지 업로드 */
+  public String uploadProfileImage(MultipartFile file, UUID userId) {
+    validateImage(file);
+
+    String fileName = generateProfileImageFileName(userId);
+    String key = s3Properties.getProfileImagePath() + fileName;
+
+    try {
+      PutObjectRequest putObjectRequest =
+          PutObjectRequest.builder()
+              .bucket(s3Properties.getBucket())
+              .key(key)
+              .contentType(file.getContentType())
+              .acl(ObjectCannedACL.PUBLIC_READ)
+              .serverSideEncryption(ServerSideEncryption.AES256)
+              .build();
+
+      s3Client.putObject(putObjectRequest, RequestBody.fromBytes(file.getBytes()));
+
+      return generatePublicUrl(key);
+
+    } catch (IOException e) {
+      throw new BusinessException(CommonErrorCode.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  /** 이미지 유효성 검사 */
+  private void validateImage(MultipartFile file) {
+    if (file == null || file.isEmpty()) {
+      throw new BusinessException(CommonErrorCode.INVALID_REQUEST);
+    }
+
+    if (file.getSize() > MAX_FILE_SIZE) {
+      throw new BusinessException(CommonErrorCode.INVALID_REQUEST);
+    }
+
+    String originalFilename = file.getOriginalFilename();
+    if (originalFilename == null || !isAllowedExtension(originalFilename)) {
+      throw new BusinessException(CommonErrorCode.INVALID_REQUEST);
+    }
+  }
+
+  /** 허용된 확장자인지 확인 */
+  private boolean isAllowedExtension(String originalFilename) {
+    String extension =
+        originalFilename.substring(originalFilename.lastIndexOf(".") + 1).toLowerCase();
+    return ALLOWED_EXTENSIONS.contains(extension);
+  }
+
+  /** 프로필 이미지 파일명 생성 */
+  private String generateProfileImageFileName(UUID userId) {
+    long timestamp = System.currentTimeMillis();
+    return userId + "_" + timestamp + ".jpg";
+  }
+
+  /** Public URL 생성 */
+  private String generatePublicUrl(String key) {
+    return String.format(
+        "https://%s.s3.%s.amazonaws.com/%s",
+        s3Properties.getBucket(), s3Properties.getRegion(), key);
+  }
+
+  /** URL에서 S3 키 추출 */
+  private String extractKeyFromUrl(String url) {
+    // URL 형식: https://{bucket}.s3.{region}.amazonaws.com/{key}
+    try {
+      String[] parts = url.split("\\?")[0].split(s3Properties.getBucket() + "/");
+      if (parts.length > 1) {
+        return parts[1];
+      }
+      return url.split("amazonaws.com/")[1].split("\\?")[0];
+    } catch (Exception e) {
+      throw new BusinessException(CommonErrorCode.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  /** 이미지 삭제 */
+  public void deleteImageByUrl(String imageUrl) {
+    if (imageUrl == null || imageUrl.isEmpty()) {
+      return;
+    }
+    try {
+      String key = extractKeyFromUrl(imageUrl);
+
+      DeleteObjectRequest deleteObjectRequest =
+          DeleteObjectRequest.builder().bucket(s3Properties.getBucket()).key(key).build();
+
+      s3Client.deleteObject(deleteObjectRequest);
+
+    } catch (Exception e) {
+      log.warn("이미지 삭제 실패 - url: {}", imageUrl, e);
+    }
+  }
+}

--- a/mopl-api/src/main/java/io/mopl/api/user/service/ProfileImageUploadService.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/service/ProfileImageUploadService.java
@@ -102,7 +102,7 @@ public class ProfileImageUploadService {
     String extension =
         originalFilename.substring(originalFilename.lastIndexOf(".") + 1).toLowerCase();
     long timestamp = System.currentTimeMillis();
-    return userId + "_" + timestamp + extension;
+    return userId + "_" + timestamp + "." + extension;
   }
 
   /** Public URL 생성 */

--- a/mopl-api/src/main/java/io/mopl/api/user/service/ProfileImageUploadService.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/service/ProfileImageUploadService.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
@@ -48,7 +49,8 @@ public class ProfileImageUploadService {
 
       return generatePublicUrl(key);
 
-    } catch (IOException e) {
+    } catch (IOException | SdkException e) {
+      log.error("프로필 이미지 업로드 실패 - userId: {}", userId, e);
       throw new BusinessException(CommonErrorCode.INTERNAL_SERVER_ERROR);
     }
   }

--- a/mopl-api/src/main/java/io/mopl/api/user/service/ProfileImageUploadService.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/service/ProfileImageUploadService.java
@@ -4,8 +4,10 @@ import io.mopl.api.common.config.S3Properties;
 import io.mopl.core.error.BusinessException;
 import io.mopl.core.error.CommonErrorCode;
 import java.io.IOException;
+import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,21 +29,28 @@ public class ProfileImageUploadService {
   private final S3Properties s3Properties;
 
   private static final List<String> ALLOWED_EXTENSIONS = Arrays.asList("jpg", "jpeg", "png");
+  private static final String DEFAULT_CONTENT_TYPE = "application/octet-stream";
   private static final long MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
 
   /** 프로필 이미지 업로드 */
   public String uploadProfileImage(MultipartFile file, UUID userId) {
     validateImage(file);
 
-    String fileName = generateProfileImageFileName(userId);
+    String fileName =
+        generateProfileImageFileName(userId, Objects.requireNonNull(file.getOriginalFilename()));
     String key = s3Properties.getProfileImagePath() + fileName;
+
+    String contentType = file.getContentType();
+    if (contentType == null || contentType.isBlank()) {
+      contentType = DEFAULT_CONTENT_TYPE;
+    }
 
     try {
       PutObjectRequest putObjectRequest =
           PutObjectRequest.builder()
               .bucket(s3Properties.getBucket())
               .key(key)
-              .contentType(file.getContentType())
+              .contentType(contentType)
               .serverSideEncryption(ServerSideEncryption.AES256)
               .build();
 
@@ -79,9 +88,11 @@ public class ProfileImageUploadService {
   }
 
   /** 프로필 이미지 파일명 생성 */
-  private String generateProfileImageFileName(UUID userId) {
+  private String generateProfileImageFileName(UUID userId, String originalFilename) {
+    String extension =
+        originalFilename.substring(originalFilename.lastIndexOf(".") + 1).toLowerCase();
     long timestamp = System.currentTimeMillis();
-    return userId + "_" + timestamp + ".jpg";
+    return userId + "_" + timestamp + extension;
   }
 
   /** Public URL 생성 */
@@ -95,12 +106,11 @@ public class ProfileImageUploadService {
   private String extractKeyFromUrl(String url) {
     // URL 형식: https://{bucket}.s3.{region}.amazonaws.com/{key}
     try {
-      String[] parts = url.split("\\?")[0].split(s3Properties.getBucket() + "/");
-      if (parts.length > 1) {
-        return parts[1];
-      }
-      return url.split("amazonaws.com/")[1].split("\\?")[0];
+      URI uri = URI.create(url);
+      String path = uri.getPath();
+      return path.startsWith("/") ? path.substring(1) : path;
     } catch (Exception e) {
+      log.error("S3 키 추출 실패 - url: {}", url, e);
       throw new BusinessException(CommonErrorCode.INTERNAL_SERVER_ERROR);
     }
   }

--- a/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
@@ -109,8 +109,7 @@ public class UserService {
             .findById(userId)
             .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
-    assert request.getName() != null;
-    if (request.getName().trim().isBlank()) {
+    if (request.getName() != null && !request.getName().isBlank()) {
       user.setName(request.getName().trim());
     }
 

--- a/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
@@ -9,6 +9,7 @@ import io.mopl.api.user.dto.ChangePasswordRequest;
 import io.mopl.api.user.dto.UserCreateRequest;
 import io.mopl.api.user.dto.UserDto;
 import io.mopl.api.user.dto.UserSummary;
+import io.mopl.api.user.dto.UserUpdateRequest;
 import io.mopl.core.error.BusinessException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @Service
@@ -25,6 +27,7 @@ public class UserService {
 
   private final UserRepository userRepository;
   private final PasswordEncoder passwordEncoder;
+  private final ProfileImageUploadService profileImageUploadService;
 
   /** 회원가입 */
   @Transactional
@@ -96,5 +99,32 @@ public class UserService {
 
     user.setTempPasswordHash(null);
     user.setTempPasswordExpiresAt(null);
+  }
+
+  /** 프로필 변경 */
+  @Transactional
+  public UserDto updateProfile(UUID userId, UserUpdateRequest request, MultipartFile profileImage) {
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+    assert request.getName() != null;
+    if (request.getName().trim().isBlank()) {
+      user.setName(request.getName().trim());
+    }
+
+    if (profileImage != null && !profileImage.isEmpty()) {
+      if (user.getProfileImageUrl() != null) {
+        profileImageUploadService.deleteImageByUrl(user.getProfileImageUrl());
+      }
+
+      String newImageUrl = profileImageUploadService.uploadProfileImage(profileImage, userId);
+      user.setProfileImageUrl(newImageUrl);
+    }
+
+    User savedUser = userRepository.save(user);
+
+    return UserDto.from(savedUser);
   }
 }

--- a/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
@@ -114,12 +114,17 @@ public class UserService {
     }
 
     if (profileImage != null && !profileImage.isEmpty()) {
-      if (user.getProfileImageUrl() != null) {
-        profileImageUploadService.deleteImageByUrl(user.getProfileImageUrl());
-      }
+      String oldImageUrl = user.getProfileImageUrl();
 
       String newImageUrl = profileImageUploadService.uploadProfileImage(profileImage, userId);
       user.setProfileImageUrl(newImageUrl);
+      if (oldImageUrl != null) {
+        try {
+          profileImageUploadService.deleteImageByUrl(oldImageUrl);
+        } catch (Exception e) {
+          log.warn("기존 프로필 이미지 삭제 실패: {}", oldImageUrl, e);
+        }
+      }
     }
 
     User savedUser = userRepository.save(user);

--- a/mopl-api/src/main/resources/application-dev.yml
+++ b/mopl-api/src/main/resources/application-dev.yml
@@ -23,6 +23,10 @@ spring:
   kafka:
     bootstrap-servers: ${MOPL_KAFKA_BOOTSTRAP:localhost:29092}
 
+security:
+  cookie:
+    secure: false
+
 server:
   port: ${MOPL_PORT:8080}
 

--- a/mopl-api/src/main/resources/application-dev.yml
+++ b/mopl-api/src/main/resources/application-dev.yml
@@ -25,7 +25,7 @@ spring:
 
 security:
   cookie:
-    secure: false
+    secure: ${SECURITY_COOKIE_SECURE:false}
 
 server:
   port: ${MOPL_PORT:8080}

--- a/mopl-api/src/main/resources/application-prod.yml
+++ b/mopl-api/src/main/resources/application-prod.yml
@@ -19,6 +19,10 @@ spring:
       host: ${REDIS_HOST}
       port: 6379
 
+security:
+  cookie:
+    secure: true
+
 logging:
   level:
     root: INFO

--- a/mopl-api/src/main/resources/application-prod.yml
+++ b/mopl-api/src/main/resources/application-prod.yml
@@ -21,7 +21,7 @@ spring:
 
 security:
   cookie:
-    secure: true
+    secure: ${SECURITY_COOKIE_SECURE:true}
 
 logging:
   level:

--- a/mopl-api/src/main/resources/application.yml
+++ b/mopl-api/src/main/resources/application.yml
@@ -44,14 +44,14 @@ spring:
             trust: smtp.gmail.com
 security:
   cookie:
-    same-site: Lax
+    same-site: ${COOKIE_SAME_SITE:Lax}
     csrf:
-      name: XSRF-TOKEN
-      http-only: false
+      name: ${CSRF_COOKIE_NAME:XSRF-TOKEN}
+      http-only: ${CSRF_HTTP_ONLY:false}
     refresh-token:
-      name: REFRESH_TOKEN
-      http-only: true
-      max-age: 604800
+      name: ${REFRESH_TOKEN_NAME:REFRESH_TOKEN}
+      http-only: ${REFRESH_TOKEN_HTTP_ONLY:true}
+      max-age: ${REFRESH_TOKEN_MAX_AGE:604800}
 
 management:
   endpoints:

--- a/mopl-api/src/main/resources/application.yml
+++ b/mopl-api/src/main/resources/application.yml
@@ -62,3 +62,11 @@ mopl:
       password: ${MOPL_ADMIN_PASSWORD:1234}
       name: ${MOPL_ADMIN_NAME:admin}
     test-user-password: ${MOPL_TEST_USER_PASSWORD:1234}
+
+aws:
+  s3:
+    access-key: ${AWS_S3_ACCESS_KEY}
+    secret-key: ${AWS_S3_SECRET_KEY}
+    region: ${AWS_S3_REGION:ap-northeast-2}
+    bucket: ${AWS_S3_BUCKET:mopl-bucket}
+    profile-image-path: ${AWS_S3_PROFILE_PATH:profiles/}

--- a/mopl-api/src/main/resources/application.yml
+++ b/mopl-api/src/main/resources/application.yml
@@ -42,6 +42,16 @@ spring:
           writetimeout: 5000
           ssl:
             trust: smtp.gmail.com
+security:
+  cookie:
+    same-site: Lax
+    csrf:
+      name: XSRF-TOKEN
+      http-only: false
+    refresh-token:
+      name: REFRESH_TOKEN
+      http-only: true
+      max-age: 604800
 
 management:
   endpoints:


### PR DESCRIPTION
## 📌 작업 개요
- 작업 내용: 유저 프로필 변경 API 구현
- 관련 이슈: #이슈번호

## 🚀 주요 변경 사항
- [x] 유저 프로필 변경 API 구현
- [x] xsrf 토큰 발급 관련해, 프론트엔드 라우팅 시 발급된 xsrf 토큰이 사라지는 문제 수정

## 🛠 DB 변경 사항
- [ ] MySQL 스키마 변경 여부 (DDL 첨부)
- [ ] Redis 키 구조 변경 여부

## 🧪 테스트 결과 (필수)
> 팀 가이드에 따라 Postman/local 환경에서의 기능 테스트를 완료해야 합니다.
- [x] **테스트 수행 완료**
- **테스트 시나리오:** (예: 이메일 중복 체크 -> 회원가입 성공 -> 로그인 확인)
프로필 사진 업데이트 및 S3 버킷에 저장 확인
및 유저 닉네임 변경 확인
- **증빙자료:** (Postman 응답 결과 캡쳐본 첨부 또는 JSON 응답 복사)
<img width="1687" height="974" alt="image" src="https://github.com/user-attachments/assets/7888e430-199f-490f-8e96-1eb4e4a3f831" />
<img width="1692" height="934" alt="image" src="https://github.com/user-attachments/assets/b7189df8-3155-4652-9957-5ee04967dc45" />
<img width="1705" height="1018" alt="image" src="https://github.com/user-attachments/assets/d8811bb0-d1aa-4458-9843-50ece6ce21d3" />
<img width="1693" height="1013" alt="image" src="https://github.com/user-attachments/assets/6fcf2143-a7be-46d9-9474-668df2fd6696" />

## ✅ 체크리스트
- [x] 코드 컨벤션(Checkstyle/Spotless)을 준수했는가?
- [x] 빌드가 성공적으로 수행되는가? (`./gradlew build`)
- [x] 불필요한 주석이나 print문은 제거했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 프로필 이미지 업로드/삭제 및 공개 URL 제공
  * 멀티파트 PATCH로 사용자 프로필(이름/이미지) 업데이트 엔드포인트 추가
  * SPA 클라이언트 라우팅을 위한 서버측 경로 포워딩 추가
  * AWS S3 연동 설정 및 S3 클라이언트 제공

* **보안 개선**
  * CSRF 발급 엔드포인트 간소화(204 응답)
  * CSRF/리프레시 토큰 쿠키 설정을 외부 구성(sameSite/secure/httpOnly/max-age)으로 전환

* **잡무(Chores)**
  * AWS SDK BOM 적용으로 S3 SDK 의존성 정리 및 버전 일관성 확보

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->