### PR TITLE
Feature/contents find 컨텐츠 목록 조회(커서 페이지네이션) 구현

### DIFF
--- a/mopl-api/src/main/java/io/mopl/api/content/controller/ContentController.java
+++ b/mopl-api/src/main/java/io/mopl/api/content/controller/ContentController.java
@@ -30,7 +30,7 @@ public class ContentController {
   }
 
   @GetMapping
-  public ResponseEntity<CursorResponseContentDto> findAll(/*@Valid*/ @ModelAttribute ContentSearchRequest contentSearchRequest) {
+  public ResponseEntity<CursorResponseContentDto> findAll(@Valid @ModelAttribute ContentSearchRequest contentSearchRequest) {
     return ResponseEntity.ok(contentService.findAll(contentSearchRequest));
   }
 

--- a/mopl-api/src/main/java/io/mopl/api/content/controller/ContentController.java
+++ b/mopl-api/src/main/java/io/mopl/api/content/controller/ContentController.java
@@ -4,9 +4,8 @@ import io.mopl.api.content.dto.ContentDto;
 import io.mopl.api.content.dto.ContentSearchRequest;
 import io.mopl.api.content.dto.CursorResponseContentDto;
 import io.mopl.api.content.service.ContentService;
-import java.util.UUID;
-
 import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -30,7 +29,8 @@ public class ContentController {
   }
 
   @GetMapping
-  public ResponseEntity<CursorResponseContentDto> findAll(@Valid @ModelAttribute ContentSearchRequest contentSearchRequest) {
+  public ResponseEntity<CursorResponseContentDto> findAll(
+      @Valid @ModelAttribute ContentSearchRequest contentSearchRequest) {
     return ResponseEntity.ok(contentService.findAll(contentSearchRequest));
   }
 

--- a/mopl-api/src/main/java/io/mopl/api/content/controller/ContentController.java
+++ b/mopl-api/src/main/java/io/mopl/api/content/controller/ContentController.java
@@ -1,13 +1,18 @@
 package io.mopl.api.content.controller;
 
 import io.mopl.api.content.dto.ContentDto;
+import io.mopl.api.content.dto.ContentSearchRequest;
+import io.mopl.api.content.dto.CursorResponseContentDto;
 import io.mopl.api.content.service.ContentService;
 import java.util.UUID;
+
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,6 +27,11 @@ public class ContentController {
   @GetMapping("/{contentId}")
   public ResponseEntity<ContentDto> findById(@PathVariable("contentId") UUID contentId) {
     return ResponseEntity.ok(contentService.findById(contentId));
+  }
+
+  @GetMapping
+  public ResponseEntity<CursorResponseContentDto> findAll(/*@Valid*/ @ModelAttribute ContentSearchRequest contentSearchRequest) {
+    return ResponseEntity.ok(contentService.findAll(contentSearchRequest));
   }
 
   @DeleteMapping("/{contentId}")

--- a/mopl-api/src/main/java/io/mopl/api/content/domain/ContentQueryRepository.java
+++ b/mopl-api/src/main/java/io/mopl/api/content/domain/ContentQueryRepository.java
@@ -1,12 +1,11 @@
 package io.mopl.api.content.domain;
 
-import java.util.List;
-
 import io.mopl.api.content.dto.ContentPage;
 import io.mopl.api.content.dto.ContentSearchRequest;
+import java.util.List;
 
 public interface ContentQueryRepository {
-	ContentPage findContentPage(ContentSearchRequest request);
+  ContentPage findContentPage(ContentSearchRequest request);
 
-	long countContents(String typeEqual, String keywordLike, List<String> tagsIn);
+  long countContents(String typeEqual, String keywordLike, List<String> tagsIn);
 }

--- a/mopl-api/src/main/java/io/mopl/api/content/domain/ContentQueryRepository.java
+++ b/mopl-api/src/main/java/io/mopl/api/content/domain/ContentQueryRepository.java
@@ -1,0 +1,12 @@
+package io.mopl.api.content.domain;
+
+import java.util.List;
+
+import io.mopl.api.content.dto.ContentPage;
+import io.mopl.api.content.dto.ContentSearchRequest;
+
+public interface ContentQueryRepository {
+	ContentPage findContentPage(ContentSearchRequest request);
+
+	long countContents(String typeEqual, String keywordLike, List<String> tagsIn);
+}

--- a/mopl-api/src/main/java/io/mopl/api/content/domain/ContentQueryRepositoryImpl.java
+++ b/mopl-api/src/main/java/io/mopl/api/content/domain/ContentQueryRepositoryImpl.java
@@ -146,12 +146,14 @@ public class ContentQueryRepositoryImpl implements ContentQueryRepository {
   private BooleanBuilder buildBaseWhere(String typeEqual, String keywordLike, List<String> tagsIn) {
     BooleanBuilder where = new BooleanBuilder();
 
-    // typeEqual이 movie, tvSeries, sport가 아닌 다른 값이 들어올 경우, 전체 contentType에 대한 컨텐츠를 검색하도록 함
     if (typeEqual != null && !typeEqual.isBlank()) {
       switch (typeEqual) {
         case "movie" -> where.and(c.type.eq(ContentType.MOVIE));
         case "tvSeries" -> where.and(c.type.eq(ContentType.TV_SERIES));
         case "sport" -> where.and(c.type.eq(ContentType.SPORT));
+        default -> throw new BusinessException(CommonErrorCode.INVALID_REQUEST)
+            .addDetail("reason", "유효하지 않은 typeEqual 값입니다.")
+            .addDetail("typeEqual", typeEqual);
       }
     }
     if (keywordLike != null && !keywordLike.isBlank()) {

--- a/mopl-api/src/main/java/io/mopl/api/content/domain/ContentQueryRepositoryImpl.java
+++ b/mopl-api/src/main/java/io/mopl/api/content/domain/ContentQueryRepositoryImpl.java
@@ -62,7 +62,8 @@ public class ContentQueryRepositoryImpl implements ContentQueryRepository {
     UUID nextIdAfter = null;
 
     if (hasNext && !fetched.isEmpty()) {
-      Content last = fetched.get(fetched.size() - 1);
+      // Content last = fetched.get(fetched.size() - 1);
+      Content last = fetched.getLast();
 
       nextIdAfter = last.getId();
       if (sortBy == SortBy.CREATED_AT) {
@@ -197,10 +198,14 @@ public class ContentQueryRepositoryImpl implements ContentQueryRepository {
     DESC;
 
     static SortDirection from(String direction) {
-      return switch (direction) {
-        case "ASCENDING" -> ASC;
-        default -> DESC;
-      };
+      // return switch (direction) {
+      //   case "ASCENDING" -> ASC;
+      //   default -> DESC;
+      // };
+		if (direction.equals("ASCENDING")) {
+			return ASC;
+		}
+		return DESC;
     }
   }
 }

--- a/mopl-api/src/main/java/io/mopl/api/content/domain/ContentQueryRepositoryImpl.java
+++ b/mopl-api/src/main/java/io/mopl/api/content/domain/ContentQueryRepositoryImpl.java
@@ -1,0 +1,219 @@
+package io.mopl.api.content.domain;
+
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import io.mopl.api.content.dto.ContentPage;
+import io.mopl.api.content.dto.ContentSearchRequest;
+import io.mopl.core.error.BusinessException;
+import io.mopl.core.error.CommonErrorCode;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ContentQueryRepositoryImpl implements ContentQueryRepository {
+	private static final QContent c = QContent.content;
+	QContentTag ct = QContentTag.contentTag;
+	QTag t = QTag.tag;
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public ContentPage findContentPage(ContentSearchRequest request) {
+		SortBy sortBy = SortBy.from(request.getSortByOrDefault());
+		SortDirection sortDirection = SortDirection.from(request.getSortDirectionOrDefault());
+
+		BooleanBuilder where = buildBaseWhere(request.getTypeEqual(), request.getKeywordLike(), request.getTagsIn());
+
+		if(request.getCursor() != null && !request.getCursor().isBlank()) {
+			if (request.getIdAfter() == null) {
+				throw new BusinessException(CommonErrorCode.INVALID_REQUEST)
+					.addDetail("reason", "cursor가 있으면 idAfter도 필수이다.");
+			}
+			BooleanExpression cursorCondition =
+				buildCursorCondition(request.getCursor(), request.getIdAfter(), sortBy, sortDirection);
+			where.and(cursorCondition);
+		}
+
+		OrderSpecifier<?> primaryOrder = buildPrimaryOrder(sortBy, sortDirection);
+
+		List<Content> fetched = queryFactory.selectFrom(c)
+			.where(where)
+			.orderBy(primaryOrder, (sortDirection == SortDirection.DESC) ? c.id.desc() : c.id.asc())
+			.limit(request.getLimitOrDefault() + 1)
+			.fetch();
+
+		boolean hasNext = fetched.size() > request.getLimit();
+		if (hasNext) {
+			fetched = fetched.subList(0, request.getLimit());
+		}
+
+		String nextCursor = null;
+		UUID nextIdAfter = null;
+
+		if (hasNext && !fetched.isEmpty()) {
+			Content last = fetched.get(fetched.size() - 1);
+
+			nextIdAfter = last.getId();
+			if (sortBy == SortBy.CREATED_AT) {
+				nextCursor = String.valueOf(last.getCreatedAt());
+			}
+			else if (sortBy == SortBy.RATE) {
+				nextCursor = String.valueOf(last.getAverageRating());
+			}
+			else {
+				nextCursor = String.valueOf(last.getWatcherCount());
+			}
+		}
+
+		return new ContentPage(fetched, hasNext, nextCursor, nextIdAfter);
+	}
+
+	@Override
+	public long countContents(String typeEqual, String keywordLike, List<String> tagsIn) {
+
+		BooleanBuilder where = buildBaseWhere(typeEqual, keywordLike, tagsIn);
+
+		Long count = queryFactory.select(c.count())
+			.from(c)
+			.where(where)
+			.fetchOne();
+
+		return count != null ? count : 0L;
+	}
+
+	private OrderSpecifier<?> buildPrimaryOrder(SortBy sortBy, SortDirection sortDirection) {
+		if (sortBy == SortBy.CREATED_AT) {
+			return (sortDirection == SortDirection.DESC) ? c.createdAt.desc() : c.createdAt.asc();
+		}
+		if (sortBy == SortBy.RATE) {
+			return (sortDirection == SortDirection.DESC) ? c.averageRating.desc() : c.averageRating.asc();
+		}
+		return (sortDirection == SortDirection.DESC) ? c.watcherCount.desc() : c.watcherCount.asc();
+	}
+
+	private BooleanExpression buildCursorCondition(String cursor, UUID idAfter, SortBy sortBy, SortDirection sortDirection) {
+		if (sortBy == SortBy.CREATED_AT) {
+			Instant time;
+			try {
+				time = Instant.parse(cursor);
+			} catch (DateTimeParseException e) {
+			    throw new BusinessException(CommonErrorCode.INVALID_REQUEST)
+					.addDetail("reason", "잘못된 cursor 형식입니다.")
+					.addDetail("cursor", cursor);
+			}
+			if (sortDirection == SortDirection.DESC) {
+				return c.createdAt.lt(time).or(c.createdAt.eq(time).and(c.id.lt(idAfter)));
+			}
+			return c.createdAt.gt(time).or(c.createdAt.eq(time).and(c.id.gt(idAfter)));
+		}
+		if (sortBy == SortBy.RATE) {
+			double rate;
+			try {
+				rate = Double.parseDouble(cursor);
+			} catch (NumberFormatException e) {
+				throw new BusinessException(CommonErrorCode.INVALID_REQUEST)
+					.addDetail("reason", "잘못된 cursor 형식입니다.")
+					.addDetail("cursor", cursor);
+			}
+
+			if (sortDirection == SortDirection.DESC) {
+				return c.averageRating.lt(rate).or(c.averageRating.eq(rate).and(c.id.lt(idAfter)));
+			}
+			return c.averageRating.gt(rate).or(c.averageRating.eq(rate).and(c.id.gt(idAfter)));
+		}
+
+		long wc;
+		try {
+			wc = Long.parseLong(cursor);
+		} catch (NumberFormatException e) {
+			throw new BusinessException(CommonErrorCode.INVALID_REQUEST)
+				.addDetail("reason", "잘못된 cursor 형식입니다.")
+				.addDetail("cursor", cursor);
+		}
+		if (sortDirection == SortDirection.DESC) {
+			return c.watcherCount.lt(wc).or(c.watcherCount.eq(wc).and(c.id.lt(idAfter)));
+		}
+		return c.watcherCount.gt(wc).or(c.watcherCount.eq(wc).and(c.id.gt(idAfter)));
+	}
+
+	private BooleanBuilder buildBaseWhere(String typeEqual, String keywordLike, List<String> tagsIn) {
+		BooleanBuilder where = new BooleanBuilder();
+
+		if (typeEqual != null && !typeEqual.isBlank()) {
+			switch (typeEqual) {
+				case "movie" -> where.and(c.type.eq(ContentType.MOVIE));
+				case "tvSeries" -> where.and(c.type.eq(ContentType.TV_SERIES));
+				case "sport" -> where.and(c.type.eq(ContentType.SPORT));
+			}
+		}
+		if (keywordLike !=null && !keywordLike.isBlank()) {
+			var descriptionAsString =
+				Expressions.stringTemplate("cast({0} as char)", c.description);
+
+			where.and(
+				c.title.containsIgnoreCase(keywordLike)
+					.or(descriptionAsString.containsIgnoreCase(keywordLike)));
+			// where.and(c.title.containsIgnoreCase(keywordLike)
+			// 	.or(c.description.containsIgnoreCase(keywordLike)));
+		}
+		if (tagsIn != null && !tagsIn.isEmpty()) {
+			int tagCount = (int) tagsIn.stream().distinct().count();
+
+			where.and(
+				c.id.in(
+					JPAExpressions.select(ct.id.contentId)
+						.from(ct)
+						.join(t).on(ct.id.tagId.eq(t.id))
+						.where(t.name.in(tagsIn))
+						.groupBy(ct.id.contentId)
+						.having(t.name.countDistinct().eq((long) tagCount))
+				)
+			);
+			// where.and(
+			// 	c.id.in(
+			// 		JPAExpressions.select(ct.id.contentId)
+			// 			.from(ct)
+			// 			.join(t).on(ct.id.tagId.eq(t.id))
+			// 			.where(t.name.in(tagsIn))
+			// 	)
+			// );
+		}
+
+		return where;
+	}
+
+
+	private enum SortBy {
+		CREATED_AT, WATCHER_COUNT, RATE;
+
+		static SortBy from(String from) {
+			return switch (from) {
+				case "createdAt" -> CREATED_AT;
+				case "rate" -> RATE;
+				default -> WATCHER_COUNT;
+			};
+		}
+	}
+
+	private enum SortDirection {
+		ASC, DESC;
+
+		static SortDirection from(String direction) {
+			return switch (direction) {
+				case "ASCENDING" -> ASC;
+				default -> DESC;
+			};
+		}
+	}
+}

--- a/mopl-api/src/main/java/io/mopl/api/content/domain/ContentQueryRepositoryImpl.java
+++ b/mopl-api/src/main/java/io/mopl/api/content/domain/ContentQueryRepositoryImpl.java
@@ -146,6 +146,7 @@ public class ContentQueryRepositoryImpl implements ContentQueryRepository {
   private BooleanBuilder buildBaseWhere(String typeEqual, String keywordLike, List<String> tagsIn) {
     BooleanBuilder where = new BooleanBuilder();
 
+    // typeEqual이 movie, tvSeries, sport가 아닌 다른 값이 들어올 경우, 전체 contentType에 대한 컨텐츠를 검색하도록 함
     if (typeEqual != null && !typeEqual.isBlank()) {
       switch (typeEqual) {
         case "movie" -> where.and(c.type.eq(ContentType.MOVIE));
@@ -197,10 +198,13 @@ public class ContentQueryRepositoryImpl implements ContentQueryRepository {
     DESC;
 
     static SortDirection from(String direction) {
-      if (direction.equals("ASCENDING")) {
-        return ASC;
-      }
-      return DESC;
+      return switch (direction) {
+        case "ASCENDING" -> ASC;
+        case "DESCENDING" -> DESC;
+        default -> throw new BusinessException(CommonErrorCode.INVALID_REQUEST)
+            .addDetail("reason", "유효하지 않은 sortDirection 값입니다.")
+            .addDetail("direction", direction);
+      };
     }
   }
 }

--- a/mopl-api/src/main/java/io/mopl/api/content/domain/ContentQueryRepositoryImpl.java
+++ b/mopl-api/src/main/java/io/mopl/api/content/domain/ContentQueryRepositoryImpl.java
@@ -1,210 +1,206 @@
 package io.mopl.api.content.domain;
 
-import java.time.Instant;
-import java.time.format.DateTimeParseException;
-import java.util.List;
-import java.util.UUID;
-
-import org.springframework.stereotype.Repository;
-
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-
 import io.mopl.api.content.dto.ContentPage;
 import io.mopl.api.content.dto.ContentSearchRequest;
 import io.mopl.core.error.BusinessException;
 import io.mopl.core.error.CommonErrorCode;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
 public class ContentQueryRepositoryImpl implements ContentQueryRepository {
-	private static final QContent c = QContent.content;
-	QContentTag ct = QContentTag.contentTag;
-	QTag t = QTag.tag;
-	private final JPAQueryFactory queryFactory;
+  private static final QContent c = QContent.content;
+  QContentTag ct = QContentTag.contentTag;
+  QTag t = QTag.tag;
+  private final JPAQueryFactory queryFactory;
 
-	@Override
-	public ContentPage findContentPage(ContentSearchRequest request) {
-		SortBy sortBy = SortBy.from(request.getSortByOrDefault());
-		SortDirection sortDirection = SortDirection.from(request.getSortDirectionOrDefault());
+  @Override
+  public ContentPage findContentPage(ContentSearchRequest request) {
+    SortBy sortBy = SortBy.from(request.getSortByOrDefault());
+    SortDirection sortDirection = SortDirection.from(request.getSortDirectionOrDefault());
 
-		BooleanBuilder where = buildBaseWhere(request.getTypeEqual(), request.getKeywordLike(), request.getTagsIn());
+    BooleanBuilder where =
+        buildBaseWhere(request.getTypeEqual(), request.getKeywordLike(), request.getTagsIn());
 
-		if(request.getCursor() != null && !request.getCursor().isBlank()) {
-			if (request.getIdAfter() == null) {
-				throw new BusinessException(CommonErrorCode.INVALID_REQUEST)
-					.addDetail("reason", "cursor가 있으면 idAfter도 필수이다.");
-			}
-			BooleanExpression cursorCondition =
-				buildCursorCondition(request.getCursor(), request.getIdAfter(), sortBy, sortDirection);
-			where.and(cursorCondition);
-		}
+    if (request.getCursor() != null && !request.getCursor().isBlank()) {
+      if (request.getIdAfter() == null) {
+        throw new BusinessException(CommonErrorCode.INVALID_REQUEST)
+            .addDetail("reason", "cursor가 있으면 idAfter도 필수이다.");
+      }
+      BooleanExpression cursorCondition =
+          buildCursorCondition(request.getCursor(), request.getIdAfter(), sortBy, sortDirection);
+      where.and(cursorCondition);
+    }
 
-		OrderSpecifier<?> primaryOrder = buildPrimaryOrder(sortBy, sortDirection);
+    OrderSpecifier<?> primaryOrder = buildPrimaryOrder(sortBy, sortDirection);
 
-		List<Content> fetched = queryFactory.selectFrom(c)
-			.where(where)
-			.orderBy(primaryOrder, (sortDirection == SortDirection.DESC) ? c.id.desc() : c.id.asc())
-			.limit(request.getLimitOrDefault() + 1)
-			.fetch();
+    List<Content> fetched =
+        queryFactory
+            .selectFrom(c)
+            .where(where)
+            .orderBy(primaryOrder, (sortDirection == SortDirection.DESC) ? c.id.desc() : c.id.asc())
+            .limit(request.getLimitOrDefault() + 1)
+            .fetch();
 
-		boolean hasNext = fetched.size() > request.getLimitOrDefault();
-		if (hasNext) {
-			fetched = fetched.subList(0, request.getLimitOrDefault());
-		}
+    boolean hasNext = fetched.size() > request.getLimitOrDefault();
+    if (hasNext) {
+      fetched = fetched.subList(0, request.getLimitOrDefault());
+    }
 
-		String nextCursor = null;
-		UUID nextIdAfter = null;
+    String nextCursor = null;
+    UUID nextIdAfter = null;
 
-		if (hasNext && !fetched.isEmpty()) {
-			Content last = fetched.get(fetched.size() - 1);
+    if (hasNext && !fetched.isEmpty()) {
+      Content last = fetched.get(fetched.size() - 1);
 
-			nextIdAfter = last.getId();
-			if (sortBy == SortBy.CREATED_AT) {
-				nextCursor = String.valueOf(last.getCreatedAt());
-			}
-			else if (sortBy == SortBy.RATE) {
-				nextCursor = String.valueOf(last.getAverageRating());
-			}
-			else {
-				nextCursor = String.valueOf(last.getWatcherCount());
-			}
-		}
+      nextIdAfter = last.getId();
+      if (sortBy == SortBy.CREATED_AT) {
+        nextCursor = String.valueOf(last.getCreatedAt());
+      } else if (sortBy == SortBy.RATE) {
+        nextCursor = String.valueOf(last.getAverageRating());
+      } else {
+        nextCursor = String.valueOf(last.getWatcherCount());
+      }
+    }
 
-		return new ContentPage(fetched, hasNext, nextCursor, nextIdAfter);
-	}
+    return new ContentPage(fetched, hasNext, nextCursor, nextIdAfter);
+  }
 
-	@Override
-	public long countContents(String typeEqual, String keywordLike, List<String> tagsIn) {
+  @Override
+  public long countContents(String typeEqual, String keywordLike, List<String> tagsIn) {
 
-		BooleanBuilder where = buildBaseWhere(typeEqual, keywordLike, tagsIn);
+    BooleanBuilder where = buildBaseWhere(typeEqual, keywordLike, tagsIn);
 
-		Long count = queryFactory.select(c.count())
-			.from(c)
-			.where(where)
-			.fetchOne();
+    Long count = queryFactory.select(c.count()).from(c).where(where).fetchOne();
 
-		return count != null ? count : 0L;
-	}
+    return count != null ? count : 0L;
+  }
 
-	private OrderSpecifier<?> buildPrimaryOrder(SortBy sortBy, SortDirection sortDirection) {
-		if (sortBy == SortBy.CREATED_AT) {
-			return (sortDirection == SortDirection.DESC) ? c.createdAt.desc() : c.createdAt.asc();
-		}
-		if (sortBy == SortBy.RATE) {
-			return (sortDirection == SortDirection.DESC) ? c.averageRating.desc() : c.averageRating.asc();
-		}
-		return (sortDirection == SortDirection.DESC) ? c.watcherCount.desc() : c.watcherCount.asc();
-	}
+  private OrderSpecifier<?> buildPrimaryOrder(SortBy sortBy, SortDirection sortDirection) {
+    if (sortBy == SortBy.CREATED_AT) {
+      return (sortDirection == SortDirection.DESC) ? c.createdAt.desc() : c.createdAt.asc();
+    }
+    if (sortBy == SortBy.RATE) {
+      return (sortDirection == SortDirection.DESC) ? c.averageRating.desc() : c.averageRating.asc();
+    }
+    return (sortDirection == SortDirection.DESC) ? c.watcherCount.desc() : c.watcherCount.asc();
+  }
 
-	private BooleanExpression buildCursorCondition(String cursor, UUID idAfter, SortBy sortBy, SortDirection sortDirection) {
-		if (sortBy == SortBy.CREATED_AT) {
-			Instant time;
-			try {
-				time = Instant.parse(cursor);
-			} catch (DateTimeParseException e) {
-			    throw new BusinessException(CommonErrorCode.INVALID_REQUEST)
-					.addDetail("reason", "잘못된 cursor 형식입니다.")
-					.addDetail("cursor", cursor);
-			}
-			if (sortDirection == SortDirection.DESC) {
-				return c.createdAt.lt(time).or(c.createdAt.eq(time).and(c.id.lt(idAfter)));
-			}
-			return c.createdAt.gt(time).or(c.createdAt.eq(time).and(c.id.gt(idAfter)));
-		}
-		if (sortBy == SortBy.RATE) {
-			double rate;
-			try {
-				rate = Double.parseDouble(cursor);
-			} catch (NumberFormatException e) {
-				throw new BusinessException(CommonErrorCode.INVALID_REQUEST)
-					.addDetail("reason", "잘못된 cursor 형식입니다.")
-					.addDetail("cursor", cursor);
-			}
+  private BooleanExpression buildCursorCondition(
+      String cursor, UUID idAfter, SortBy sortBy, SortDirection sortDirection) {
+    if (sortBy == SortBy.CREATED_AT) {
+      Instant time;
+      try {
+        time = Instant.parse(cursor);
+      } catch (DateTimeParseException e) {
+        throw new BusinessException(CommonErrorCode.INVALID_REQUEST)
+            .addDetail("reason", "잘못된 cursor 형식입니다.")
+            .addDetail("cursor", cursor);
+      }
+      if (sortDirection == SortDirection.DESC) {
+        return c.createdAt.lt(time).or(c.createdAt.eq(time).and(c.id.lt(idAfter)));
+      }
+      return c.createdAt.gt(time).or(c.createdAt.eq(time).and(c.id.gt(idAfter)));
+    }
+    if (sortBy == SortBy.RATE) {
+      double rate;
+      try {
+        rate = Double.parseDouble(cursor);
+      } catch (NumberFormatException e) {
+        throw new BusinessException(CommonErrorCode.INVALID_REQUEST)
+            .addDetail("reason", "잘못된 cursor 형식입니다.")
+            .addDetail("cursor", cursor);
+      }
 
-			if (sortDirection == SortDirection.DESC) {
-				return c.averageRating.lt(rate).or(c.averageRating.eq(rate).and(c.id.lt(idAfter)));
-			}
-			return c.averageRating.gt(rate).or(c.averageRating.eq(rate).and(c.id.gt(idAfter)));
-		}
+      if (sortDirection == SortDirection.DESC) {
+        return c.averageRating.lt(rate).or(c.averageRating.eq(rate).and(c.id.lt(idAfter)));
+      }
+      return c.averageRating.gt(rate).or(c.averageRating.eq(rate).and(c.id.gt(idAfter)));
+    }
 
-		long wc;
-		try {
-			wc = Long.parseLong(cursor);
-		} catch (NumberFormatException e) {
-			throw new BusinessException(CommonErrorCode.INVALID_REQUEST)
-				.addDetail("reason", "잘못된 cursor 형식입니다.")
-				.addDetail("cursor", cursor);
-		}
-		if (sortDirection == SortDirection.DESC) {
-			return c.watcherCount.lt(wc).or(c.watcherCount.eq(wc).and(c.id.lt(idAfter)));
-		}
-		return c.watcherCount.gt(wc).or(c.watcherCount.eq(wc).and(c.id.gt(idAfter)));
-	}
+    long wc;
+    try {
+      wc = Long.parseLong(cursor);
+    } catch (NumberFormatException e) {
+      throw new BusinessException(CommonErrorCode.INVALID_REQUEST)
+          .addDetail("reason", "잘못된 cursor 형식입니다.")
+          .addDetail("cursor", cursor);
+    }
+    if (sortDirection == SortDirection.DESC) {
+      return c.watcherCount.lt(wc).or(c.watcherCount.eq(wc).and(c.id.lt(idAfter)));
+    }
+    return c.watcherCount.gt(wc).or(c.watcherCount.eq(wc).and(c.id.gt(idAfter)));
+  }
 
-	private BooleanBuilder buildBaseWhere(String typeEqual, String keywordLike, List<String> tagsIn) {
-		BooleanBuilder where = new BooleanBuilder();
+  private BooleanBuilder buildBaseWhere(String typeEqual, String keywordLike, List<String> tagsIn) {
+    BooleanBuilder where = new BooleanBuilder();
 
-		if (typeEqual != null && !typeEqual.isBlank()) {
-			switch (typeEqual) {
-				case "movie" -> where.and(c.type.eq(ContentType.MOVIE));
-				case "tvSeries" -> where.and(c.type.eq(ContentType.TV_SERIES));
-				case "sport" -> where.and(c.type.eq(ContentType.SPORT));
-			}
-		}
-		if (keywordLike !=null && !keywordLike.isBlank()) {
-			var descriptionAsString =
-				Expressions.stringTemplate("cast({0} as char)", c.description);
+    if (typeEqual != null && !typeEqual.isBlank()) {
+      switch (typeEqual) {
+        case "movie" -> where.and(c.type.eq(ContentType.MOVIE));
+        case "tvSeries" -> where.and(c.type.eq(ContentType.TV_SERIES));
+        case "sport" -> where.and(c.type.eq(ContentType.SPORT));
+      }
+    }
+    if (keywordLike != null && !keywordLike.isBlank()) {
+      var descriptionAsString = Expressions.stringTemplate("cast({0} as char)", c.description);
 
-			where.and(
-				c.title.containsIgnoreCase(keywordLike)
-					.or(descriptionAsString.containsIgnoreCase(keywordLike)));
+      where.and(
+          c.title
+              .containsIgnoreCase(keywordLike)
+              .or(descriptionAsString.containsIgnoreCase(keywordLike)));
+    }
+    if (tagsIn != null && !tagsIn.isEmpty()) {
+      int tagCount = (int) tagsIn.stream().distinct().count();
 
-		}
-		if (tagsIn != null && !tagsIn.isEmpty()) {
-			int tagCount = (int) tagsIn.stream().distinct().count();
+      where.and(
+          c.id.in(
+              JPAExpressions.select(ct.id.contentId)
+                  .from(ct)
+                  .join(t)
+                  .on(ct.id.tagId.eq(t.id))
+                  .where(t.name.in(tagsIn))
+                  .groupBy(ct.id.contentId)
+                  .having(t.name.countDistinct().eq((long) tagCount))));
+    }
 
-			where.and(
-				c.id.in(
-					JPAExpressions.select(ct.id.contentId)
-						.from(ct)
-						.join(t).on(ct.id.tagId.eq(t.id))
-						.where(t.name.in(tagsIn))
-						.groupBy(ct.id.contentId)
-						.having(t.name.countDistinct().eq((long) tagCount))
-				)
-			);
-		}
+    return where;
+  }
 
-		return where;
-	}
+  private enum SortBy {
+    CREATED_AT,
+    WATCHER_COUNT,
+    RATE;
 
+    static SortBy from(String from) {
+      return switch (from) {
+        case "createdAt" -> CREATED_AT;
+        case "rate" -> RATE;
+        default -> WATCHER_COUNT;
+      };
+    }
+  }
 
-	private enum SortBy {
-		CREATED_AT, WATCHER_COUNT, RATE;
+  private enum SortDirection {
+    ASC,
+    DESC;
 
-		static SortBy from(String from) {
-			return switch (from) {
-				case "createdAt" -> CREATED_AT;
-				case "rate" -> RATE;
-				default -> WATCHER_COUNT;
-			};
-		}
-	}
-
-	private enum SortDirection {
-		ASC, DESC;
-
-		static SortDirection from(String direction) {
-			return switch (direction) {
-				case "ASCENDING" -> ASC;
-				default -> DESC;
-			};
-		}
-	}
+    static SortDirection from(String direction) {
+      return switch (direction) {
+        case "ASCENDING" -> ASC;
+        default -> DESC;
+      };
+    }
+  }
 }

--- a/mopl-api/src/main/java/io/mopl/api/content/domain/ContentQueryRepositoryImpl.java
+++ b/mopl-api/src/main/java/io/mopl/api/content/domain/ContentQueryRepositoryImpl.java
@@ -53,9 +53,9 @@ public class ContentQueryRepositoryImpl implements ContentQueryRepository {
 			.limit(request.getLimitOrDefault() + 1)
 			.fetch();
 
-		boolean hasNext = fetched.size() > request.getLimit();
+		boolean hasNext = fetched.size() > request.getLimitOrDefault();
 		if (hasNext) {
-			fetched = fetched.subList(0, request.getLimit());
+			fetched = fetched.subList(0, request.getLimitOrDefault());
 		}
 
 		String nextCursor = null;
@@ -164,8 +164,7 @@ public class ContentQueryRepositoryImpl implements ContentQueryRepository {
 			where.and(
 				c.title.containsIgnoreCase(keywordLike)
 					.or(descriptionAsString.containsIgnoreCase(keywordLike)));
-			// where.and(c.title.containsIgnoreCase(keywordLike)
-			// 	.or(c.description.containsIgnoreCase(keywordLike)));
+
 		}
 		if (tagsIn != null && !tagsIn.isEmpty()) {
 			int tagCount = (int) tagsIn.stream().distinct().count();
@@ -180,14 +179,6 @@ public class ContentQueryRepositoryImpl implements ContentQueryRepository {
 						.having(t.name.countDistinct().eq((long) tagCount))
 				)
 			);
-			// where.and(
-			// 	c.id.in(
-			// 		JPAExpressions.select(ct.id.contentId)
-			// 			.from(ct)
-			// 			.join(t).on(ct.id.tagId.eq(t.id))
-			// 			.where(t.name.in(tagsIn))
-			// 	)
-			// );
 		}
 
 		return where;

--- a/mopl-api/src/main/java/io/mopl/api/content/domain/ContentQueryRepositoryImpl.java
+++ b/mopl-api/src/main/java/io/mopl/api/content/domain/ContentQueryRepositoryImpl.java
@@ -151,9 +151,10 @@ public class ContentQueryRepositoryImpl implements ContentQueryRepository {
         case "movie" -> where.and(c.type.eq(ContentType.MOVIE));
         case "tvSeries" -> where.and(c.type.eq(ContentType.TV_SERIES));
         case "sport" -> where.and(c.type.eq(ContentType.SPORT));
-        default -> throw new BusinessException(CommonErrorCode.INVALID_REQUEST)
-            .addDetail("reason", "유효하지 않은 typeEqual 값입니다.")
-            .addDetail("typeEqual", typeEqual);
+        default ->
+            throw new BusinessException(CommonErrorCode.INVALID_REQUEST)
+                .addDetail("reason", "유효하지 않은 typeEqual 값입니다.")
+                .addDetail("typeEqual", typeEqual);
       }
     }
     if (keywordLike != null && !keywordLike.isBlank()) {
@@ -191,9 +192,10 @@ public class ContentQueryRepositoryImpl implements ContentQueryRepository {
         case "createdAt" -> CREATED_AT;
         case "rate" -> RATE;
         case "watcherCount" -> WATCHER_COUNT;
-        default -> throw new BusinessException(CommonErrorCode.INVALID_REQUEST)
-             .addDetail("reason", "유효하지 않은 sortBy 값입니다.")
-             .addDetail("sortBy", from);
+        default ->
+            throw new BusinessException(CommonErrorCode.INVALID_REQUEST)
+                .addDetail("reason", "유효하지 않은 sortBy 값입니다.")
+                .addDetail("sortBy", from);
       };
     }
   }
@@ -206,9 +208,10 @@ public class ContentQueryRepositoryImpl implements ContentQueryRepository {
       return switch (direction) {
         case "ASCENDING" -> ASC;
         case "DESCENDING" -> DESC;
-        default -> throw new BusinessException(CommonErrorCode.INVALID_REQUEST)
-            .addDetail("reason", "유효하지 않은 sortDirection 값입니다.")
-            .addDetail("direction", direction);
+        default ->
+            throw new BusinessException(CommonErrorCode.INVALID_REQUEST)
+                .addDetail("reason", "유효하지 않은 sortDirection 값입니다.")
+                .addDetail("direction", direction);
       };
     }
   }

--- a/mopl-api/src/main/java/io/mopl/api/content/domain/ContentQueryRepositoryImpl.java
+++ b/mopl-api/src/main/java/io/mopl/api/content/domain/ContentQueryRepositoryImpl.java
@@ -62,7 +62,6 @@ public class ContentQueryRepositoryImpl implements ContentQueryRepository {
     UUID nextIdAfter = null;
 
     if (hasNext && !fetched.isEmpty()) {
-      // Content last = fetched.get(fetched.size() - 1);
       Content last = fetched.getLast();
 
       nextIdAfter = last.getId();
@@ -198,10 +197,6 @@ public class ContentQueryRepositoryImpl implements ContentQueryRepository {
     DESC;
 
     static SortDirection from(String direction) {
-      // return switch (direction) {
-      //   case "ASCENDING" -> ASC;
-      //   default -> DESC;
-      // };
 		if (direction.equals("ASCENDING")) {
 			return ASC;
 		}

--- a/mopl-api/src/main/java/io/mopl/api/content/domain/ContentQueryRepositoryImpl.java
+++ b/mopl-api/src/main/java/io/mopl/api/content/domain/ContentQueryRepositoryImpl.java
@@ -197,10 +197,10 @@ public class ContentQueryRepositoryImpl implements ContentQueryRepository {
     DESC;
 
     static SortDirection from(String direction) {
-		if (direction.equals("ASCENDING")) {
-			return ASC;
-		}
-		return DESC;
+      if (direction.equals("ASCENDING")) {
+        return ASC;
+      }
+      return DESC;
     }
   }
 }

--- a/mopl-api/src/main/java/io/mopl/api/content/domain/ContentQueryRepositoryImpl.java
+++ b/mopl-api/src/main/java/io/mopl/api/content/domain/ContentQueryRepositoryImpl.java
@@ -21,8 +21,8 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class ContentQueryRepositoryImpl implements ContentQueryRepository {
   private static final QContent c = QContent.content;
-  QContentTag ct = QContentTag.contentTag;
-  QTag t = QTag.tag;
+  private static final QContentTag ct = QContentTag.contentTag;
+  private static final QTag t = QTag.tag;
   private final JPAQueryFactory queryFactory;
 
   @Override

--- a/mopl-api/src/main/java/io/mopl/api/content/domain/ContentQueryRepositoryImpl.java
+++ b/mopl-api/src/main/java/io/mopl/api/content/domain/ContentQueryRepositoryImpl.java
@@ -190,7 +190,10 @@ public class ContentQueryRepositoryImpl implements ContentQueryRepository {
       return switch (from) {
         case "createdAt" -> CREATED_AT;
         case "rate" -> RATE;
-        default -> WATCHER_COUNT;
+        case "watcherCount" -> WATCHER_COUNT;
+        default -> throw new BusinessException(CommonErrorCode.INVALID_REQUEST)
+             .addDetail("reason", "유효하지 않은 sortBy 값입니다.")
+             .addDetail("sortBy", from);
       };
     }
   }

--- a/mopl-api/src/main/java/io/mopl/api/content/domain/ContentRepository.java
+++ b/mopl-api/src/main/java/io/mopl/api/content/domain/ContentRepository.java
@@ -5,4 +5,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ContentRepository extends JpaRepository<Content, UUID> {}
+public interface ContentRepository extends JpaRepository<Content, UUID>, ContentQueryRepository {}

--- a/mopl-api/src/main/java/io/mopl/api/content/domain/ContentTagRepository.java
+++ b/mopl-api/src/main/java/io/mopl/api/content/domain/ContentTagRepository.java
@@ -20,8 +20,9 @@ public interface ContentTagRepository extends JpaRepository<ContentTag, ContentT
   @Query("delete from ContentTag ct where ct.id.contentId = :contentId")
   void deleteByIdContentId(@Param("contentId") UUID contentId);
 
-  @Query("select ct.id.contentId, t.name " +
-         "from ContentTag ct join Tag t on ct.id.tagId = t.id " +
-         "where ct.id.contentId in :contentIds")
+  @Query(
+      "select ct.id.contentId, t.name "
+          + "from ContentTag ct join Tag t on ct.id.tagId = t.id "
+          + "where ct.id.contentId in :contentIds")
   List<Object[]> findTagNamesByContentIds(@Param("contentIds") List<UUID> contentIds);
 }

--- a/mopl-api/src/main/java/io/mopl/api/content/domain/ContentTagRepository.java
+++ b/mopl-api/src/main/java/io/mopl/api/content/domain/ContentTagRepository.java
@@ -19,4 +19,9 @@ public interface ContentTagRepository extends JpaRepository<ContentTag, ContentT
   @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query("delete from ContentTag ct where ct.id.contentId = :contentId")
   void deleteByIdContentId(@Param("contentId") UUID contentId);
+
+  @Query("select ct.id.contentId, t.name " +
+         "from ContentTag ct join Tag t on ct.id.tagId = t.id " +
+         "where ct.id.contentId in :contentIds")
+  List<Object[]> findTagNamesByContentIds(@Param("contentIds") List<UUID> contentIds);
 }

--- a/mopl-api/src/main/java/io/mopl/api/content/dto/ContentPage.java
+++ b/mopl-api/src/main/java/io/mopl/api/content/dto/ContentPage.java
@@ -1,17 +1,16 @@
 package io.mopl.api.content.dto;
 
+import io.mopl.api.content.domain.Content;
 import java.util.List;
 import java.util.UUID;
-
-import io.mopl.api.content.domain.Content;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public class ContentPage {
-	private final List<Content> contents;
-	private final boolean hasNext;
-	private final String nextCursor;
-	private final UUID nextIdAfter;
+  private final List<Content> contents;
+  private final boolean hasNext;
+  private final String nextCursor;
+  private final UUID nextIdAfter;
 }

--- a/mopl-api/src/main/java/io/mopl/api/content/dto/ContentPage.java
+++ b/mopl-api/src/main/java/io/mopl/api/content/dto/ContentPage.java
@@ -1,0 +1,17 @@
+package io.mopl.api.content.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+import io.mopl.api.content.domain.Content;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ContentPage {
+	private final List<Content> contents;
+	private final boolean hasNext;
+	private final String nextCursor;
+	private final UUID nextIdAfter;
+}

--- a/mopl-api/src/main/java/io/mopl/api/content/dto/ContentSearchRequest.java
+++ b/mopl-api/src/main/java/io/mopl/api/content/dto/ContentSearchRequest.java
@@ -13,7 +13,7 @@ import lombok.Setter;
 @Setter
 public class ContentSearchRequest {
 	@Pattern(
-		regexp = "^(movie|tvSeries|sport)$?",
+		regexp = "^(movie|tvSeries|sport)?$",
 		message = "typeEqual must be movie, tvSeries or sport."
 	)
 	private String typeEqual;
@@ -27,13 +27,13 @@ public class ContentSearchRequest {
 	private Integer limit;
 
 	@Pattern(
-		regexp = "^(ASCENDING|DESCENDING)$?",
+		regexp = "^(ASCENDING|DESCENDING)?$",
 		message = "sortDirection must be ASCENDING or DESCENDING."
 	)
 	private String sortDirection;
 
 	@Pattern(
-		regexp = "^(createdAt|watcherCount|rate)$?",
+		regexp = "^(createdAt|watcherCount|rate)?$",
 		message = "sortBy must be createdAt or watcherCount or rate."
 	)
 	private String sortBy;

--- a/mopl-api/src/main/java/io/mopl/api/content/dto/ContentSearchRequest.java
+++ b/mopl-api/src/main/java/io/mopl/api/content/dto/ContentSearchRequest.java
@@ -1,53 +1,49 @@
 package io.mopl.api.content.dto;
 
-import java.util.List;
-import java.util.UUID;
-
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Pattern;
+import java.util.List;
+import java.util.UUID;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 public class ContentSearchRequest {
-	@Pattern(
-		regexp = "^(movie|tvSeries|sport)?$",
-		message = "typeEqual must be movie, tvSeries or sport."
-	)
-	private String typeEqual;
-	private String keywordLike;
-	private List<String> tagsIn;
-	private String cursor;
-	private UUID idAfter;
+  @Pattern(
+      regexp = "^(movie|tvSeries|sport)?$",
+      message = "typeEqual must be movie, tvSeries or sport.")
+  private String typeEqual;
 
-	@Min(10)
-	@Max(50)
-	private Integer limit;
+  private String keywordLike;
+  private List<String> tagsIn;
+  private String cursor;
+  private UUID idAfter;
 
-	@Pattern(
-		regexp = "^(ASCENDING|DESCENDING)?$",
-		message = "sortDirection must be ASCENDING or DESCENDING."
-	)
-	private String sortDirection;
+  @Min(10)
+  @Max(50)
+  private Integer limit;
 
-	@Pattern(
-		regexp = "^(createdAt|watcherCount|rate)?$",
-		message = "sortBy must be createdAt or watcherCount or rate."
-	)
-	private String sortBy;
+  @Pattern(
+      regexp = "^(ASCENDING|DESCENDING)?$",
+      message = "sortDirection must be ASCENDING or DESCENDING.")
+  private String sortDirection;
 
-	public int getLimitOrDefault() {
-		return limit != null ? limit : 20;
-	}
+  @Pattern(
+      regexp = "^(createdAt|watcherCount|rate)?$",
+      message = "sortBy must be createdAt or watcherCount or rate.")
+  private String sortBy;
 
-	public String getSortDirectionOrDefault() {
-		return (sortDirection == null || sortDirection.isBlank()) ? "DESCENDING" : sortDirection;
-	}
+  public int getLimitOrDefault() {
+    return limit != null ? limit : 20;
+  }
 
-	public String getSortByOrDefault() {
-		return (sortBy == null || sortBy.isBlank()) ? "watcherCount" : sortBy;
-	}
+  public String getSortDirectionOrDefault() {
+    return (sortDirection == null || sortDirection.isBlank()) ? "DESCENDING" : sortDirection;
+  }
 
+  public String getSortByOrDefault() {
+    return (sortBy == null || sortBy.isBlank()) ? "watcherCount" : sortBy;
+  }
 }

--- a/mopl-api/src/main/java/io/mopl/api/content/dto/ContentSearchRequest.java
+++ b/mopl-api/src/main/java/io/mopl/api/content/dto/ContentSearchRequest.java
@@ -1,0 +1,53 @@
+package io.mopl.api.content.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ContentSearchRequest {
+	@Pattern(
+		regexp = "^(movie|tvSeries|sport)$?",
+		message = "typeEqual must be movie, tvSeries or sport."
+	)
+	private String typeEqual;
+	private String keywordLike;
+	private List<String> tagsIn;
+	private String cursor;
+	private UUID idAfter;
+
+	@Min(10)
+	@Max(50)
+	private Integer limit;
+
+	@Pattern(
+		regexp = "^(ASCENDING|DESCENDING)$?",
+		message = "sortDirection must be ASCENDING or DESCENDING."
+	)
+	private String sortDirection;
+
+	@Pattern(
+		regexp = "^(createdAt|watcherCount|rate)$?",
+		message = "sortBy must be createdAt or watcherCount or rate."
+	)
+	private String sortBy;
+
+	public int getLimitOrDefault() {
+		return limit != null ? limit : 20;
+	}
+
+	public String getSortDirectionOrDefault() {
+		return (sortDirection == null || sortDirection.isBlank()) ? "DESCENDING" : sortDirection;
+	}
+
+	public String getSortByOrDefault() {
+		return (sortBy == null || sortBy.isBlank()) ? "watcherCount" : sortBy;
+	}
+
+}

--- a/mopl-api/src/main/java/io/mopl/api/content/dto/CursorResponseContentDto.java
+++ b/mopl-api/src/main/java/io/mopl/api/content/dto/CursorResponseContentDto.java
@@ -1,0 +1,23 @@
+package io.mopl.api.content.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CursorResponseContentDto {
+	private List<ContentDto> data;
+	private String nextCursor;
+	private UUID nextIdAfter;
+	private boolean hasNext;
+	private long totalCount;
+	private String sortBy;
+	private String sortDirection;
+}

--- a/mopl-api/src/main/java/io/mopl/api/content/dto/CursorResponseContentDto.java
+++ b/mopl-api/src/main/java/io/mopl/api/content/dto/CursorResponseContentDto.java
@@ -2,7 +2,6 @@ package io.mopl.api.content.dto;
 
 import java.util.List;
 import java.util.UUID;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,11 +12,11 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class CursorResponseContentDto {
-	private List<ContentDto> data;
-	private String nextCursor;
-	private UUID nextIdAfter;
-	private boolean hasNext;
-	private long totalCount;
-	private String sortBy;
-	private String sortDirection;
+  private List<ContentDto> data;
+  private String nextCursor;
+  private UUID nextIdAfter;
+  private boolean hasNext;
+  private long totalCount;
+  private String sortBy;
+  private String sortDirection;
 }

--- a/mopl-api/src/main/java/io/mopl/api/content/service/ContentService.java
+++ b/mopl-api/src/main/java/io/mopl/api/content/service/ContentService.java
@@ -70,6 +70,7 @@ public class ContentService {
     log.info("컨텐츠 삭제 완료: contentId: {}", contentId);
   }
 
+  @Transactional(readOnly = true)
   public CursorResponseContentDto findAll(ContentSearchRequest contentSearchRequest) {
 
     String sortBy = contentSearchRequest.getSortByOrDefault();

--- a/mopl-api/src/main/java/io/mopl/api/content/service/ContentService.java
+++ b/mopl-api/src/main/java/io/mopl/api/content/service/ContentService.java
@@ -5,13 +5,22 @@ import io.mopl.api.content.domain.Content;
 import io.mopl.api.content.domain.ContentRepository;
 import io.mopl.api.content.domain.ContentTagRepository;
 import io.mopl.api.content.dto.ContentDto;
+import io.mopl.api.content.dto.ContentPage;
+import io.mopl.api.content.dto.ContentSearchRequest;
+import io.mopl.api.content.dto.CursorResponseContentDto;
 import io.mopl.api.playlist.repository.PlaylistContentRepository;
 import io.mopl.api.review.repository.ReviewRepository;
 import io.mopl.core.error.BusinessException;
+
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -62,5 +71,53 @@ public class ContentService {
     contentTagRepository.deleteByIdContentId(contentId);
     contentRepository.deleteById(contentId);
     log.info("컨텐츠 삭제 완료: contentId: {}", contentId);
+  }
+
+  public CursorResponseContentDto findAll(ContentSearchRequest contentSearchRequest) {
+
+    String sortBy = contentSearchRequest.getSortByOrDefault();
+    String sortDirection = contentSearchRequest.getSortDirectionOrDefault();
+
+    ContentPage page = contentRepository.findContentPage(contentSearchRequest);
+
+    long totalCount = contentRepository.countContents(
+        contentSearchRequest.getTypeEqual(),
+        contentSearchRequest.getKeywordLike(),
+        contentSearchRequest.getTagsIn()
+    );
+
+    List<Content> contents = page.getContents();
+    List<UUID> contentIds = contents.stream().map(Content::getId).toList();
+
+    Map<UUID, List<String>> tagsByContentId = new HashMap<>();
+    for (Object[] row : contentTagRepository.findTagNamesByContentIds(contentIds)) {
+      UUID contentId = (UUID) row[0];
+      String tagName = (String) row[1];
+      tagsByContentId.computeIfAbsent(contentId, k -> new ArrayList<>()).add(tagName);
+    }
+
+    List<ContentDto> data = contents.stream()
+        .map(c -> new ContentDto(
+            c.getId(),
+            c.getType(),
+            c.getTitle(),
+            c.getDescription(),
+            c.getThumbnailUrl(),
+            tagsByContentId.getOrDefault(c.getId(), List.of()),
+            c.getAverageRating(),
+            c.getReviewCount(),
+            c.getWatcherCount()
+        ))
+        .toList();
+
+    return CursorResponseContentDto.builder()
+        .data(data)
+        .nextCursor(page.getNextCursor())
+        .nextIdAfter(page.getNextIdAfter())
+        .hasNext(page.isHasNext())
+        .totalCount(totalCount)
+        .sortBy(sortBy)
+        .sortDirection(sortDirection)
+        .build();
   }
 }

--- a/mopl-api/src/main/java/io/mopl/api/content/service/ContentService.java
+++ b/mopl-api/src/main/java/io/mopl/api/content/service/ContentService.java
@@ -11,16 +11,13 @@ import io.mopl.api.content.dto.CursorResponseContentDto;
 import io.mopl.api.playlist.repository.PlaylistContentRepository;
 import io.mopl.api.review.repository.ReviewRepository;
 import io.mopl.core.error.BusinessException;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -80,11 +77,11 @@ public class ContentService {
 
     ContentPage page = contentRepository.findContentPage(contentSearchRequest);
 
-    long totalCount = contentRepository.countContents(
-        contentSearchRequest.getTypeEqual(),
-        contentSearchRequest.getKeywordLike(),
-        contentSearchRequest.getTagsIn()
-    );
+    long totalCount =
+        contentRepository.countContents(
+            contentSearchRequest.getTypeEqual(),
+            contentSearchRequest.getKeywordLike(),
+            contentSearchRequest.getTagsIn());
 
     List<Content> contents = page.getContents();
     List<UUID> contentIds = contents.stream().map(Content::getId).toList();
@@ -96,19 +93,21 @@ public class ContentService {
       tagsByContentId.computeIfAbsent(contentId, k -> new ArrayList<>()).add(tagName);
     }
 
-    List<ContentDto> data = contents.stream()
-        .map(c -> new ContentDto(
-            c.getId(),
-            c.getType(),
-            c.getTitle(),
-            c.getDescription(),
-            c.getThumbnailUrl(),
-            tagsByContentId.getOrDefault(c.getId(), List.of()),
-            c.getAverageRating(),
-            c.getReviewCount(),
-            c.getWatcherCount()
-        ))
-        .toList();
+    List<ContentDto> data =
+        contents.stream()
+            .map(
+                c ->
+                    new ContentDto(
+                        c.getId(),
+                        c.getType(),
+                        c.getTitle(),
+                        c.getDescription(),
+                        c.getThumbnailUrl(),
+                        tagsByContentId.getOrDefault(c.getId(), List.of()),
+                        c.getAverageRating(),
+                        c.getReviewCount(),
+                        c.getWatcherCount()))
+            .toList();
 
     return CursorResponseContentDto.builder()
         .data(data)


### PR DESCRIPTION
## 📌 작업 개요
- 작업 내용: 컨텐츠 목록 조회(커서 페이지네이션) 구현
- 관련 이슈: 

## 🚀 주요 변경 사항
- 컨텐츠 목록 조회 기능 구현
-
## 🛠 DB 변경 사항
- [ ] MySQL 스키마 변경 여부 (DDL 첨부)
- [ ] Redis 키 구조 변경 여부

## 🧪 테스트 결과 (필수)
> 팀 가이드에 따라 Postman/local 환경에서의 기능 테스트를 완료해야 합니다.

### Postman에서 테스트

<img width="1367" height="708" alt="image" src="https://github.com/user-attachments/assets/8633629f-b753-4ca3-a395-463c53f184da" />
<img width="1341" height="325" alt="image" src="https://github.com/user-attachments/assets/eaf53a09-35b8-471e-b42d-c818d66d767a" />
<img width="1337" height="781" alt="image" src="https://github.com/user-attachments/assets/0036d0c5-fbd0-48f2-b24e-ca4c1c5695df" />
<img width="1375" height="671" alt="image" src="https://github.com/user-attachments/assets/5f196248-ed7e-44de-8c04-ccf02ed61eb2" />
<img width="1370" height="817" alt="image" src="https://github.com/user-attachments/assets/a523b0e7-045f-4d1a-97e6-c1e89970ddcb" />

### 로컬 테스트
<img width="1629" height="765" alt="image" src="https://github.com/user-attachments/assets/6093a5e4-3a99-4de0-ab85-9f23c3db7d98" />
<img width="1582" height="764" alt="image" src="https://github.com/user-attachments/assets/a9ff2035-caae-4813-ae4f-374676b8a42d" />
<img width="1510" height="746" alt="image" src="https://github.com/user-attachments/assets/7e2117fd-791b-4e7c-b0fa-a23a93204066" />

- [x] **테스트 수행 완료**
- **테스트 시나리오:** (예: 이메일 중복 체크 -> 회원가입 성공 -> 로그인 확인)
- **증빙자료:** (Postman 응답 결과 캡쳐본 첨부 또는 JSON 응답 복사)

## ✅ 체크리스트
- [x] 코드 컨벤션(Checkstyle/Spotless)을 준수했는가?
- [x] 빌드가 성공적으로 수행되는가? (`./gradlew build`)
- [x] 불필요한 주석이나 print문은 제거했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 콘텐츠 조회 API 추가: 검색·필터(유형, 키워드, 태그) 지원
  * 정렬 옵션 제공(생성일/평점/시청자수) 및 기본값·유효성 검사 적용
  * 커서 기반 페이지네이션 도입: 다음 페이지 유무, 다음 커서 및 다음 ID 반환
  * 응답에 각 콘텐츠별 태그 집계 및 전체 매칭 건수(totalCount) 포함

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->