### PR TITLE
사용자 목록 조회 API 구현

### DIFF
--- a/mopl-api/src/main/java/io/mopl/api/user/controller/UserController.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/controller/UserController.java
@@ -2,9 +2,12 @@ package io.mopl.api.user.controller;
 
 import io.mopl.api.common.config.AuthUser;
 import io.mopl.api.user.dto.ChangePasswordRequest;
+import io.mopl.api.user.dto.CursorResponseUserDto;
 import io.mopl.api.user.dto.UserCreateRequest;
 import io.mopl.api.user.dto.UserDto;
+import io.mopl.api.user.dto.UserSearchRequest;
 import io.mopl.api.user.dto.UserUpdateRequest;
+import io.mopl.api.user.service.UserQueryService;
 import io.mopl.api.user.service.UserService;
 import io.mopl.core.error.BusinessException;
 import io.mopl.core.error.CommonErrorCode;
@@ -15,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -33,6 +37,15 @@ import org.springframework.web.multipart.MultipartFile;
 public class UserController {
 
   private final UserService userService;
+  private final UserQueryService userQueryService;
+
+  /** 사용자 목록 조회 */
+  @GetMapping
+  @PreAuthorize("hasRole('ADMIN')")
+  public ResponseEntity<CursorResponseUserDto> findUsers(@Valid UserSearchRequest request) {
+    CursorResponseUserDto response = userQueryService.findUsers(request);
+    return ResponseEntity.ok(response);
+  }
 
   /** 회원가입 */
   @PostMapping

--- a/mopl-api/src/main/java/io/mopl/api/user/domain/UserRepository.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/domain/UserRepository.java
@@ -26,4 +26,6 @@ public interface UserRepository extends JpaRepository<User, UUID>, UserRepositor
       "UPDATE User u SET u.tempPasswordHash = null, u.tempPasswordExpiresAt = null "
           + "WHERE u.tempPasswordHash IS NOT NULL AND u.tempPasswordExpiresAt <= :now")
   int clearExpiredTempPasswords(@Param("now") Instant now);
+
+  String role(UserRole role);
 }

--- a/mopl-api/src/main/java/io/mopl/api/user/domain/UserRepository.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/domain/UserRepository.java
@@ -26,6 +26,4 @@ public interface UserRepository extends JpaRepository<User, UUID>, UserRepositor
       "UPDATE User u SET u.tempPasswordHash = null, u.tempPasswordExpiresAt = null "
           + "WHERE u.tempPasswordHash IS NOT NULL AND u.tempPasswordExpiresAt <= :now")
   int clearExpiredTempPasswords(@Param("now") Instant now);
-
-  String role(UserRole role);
 }

--- a/mopl-api/src/main/java/io/mopl/api/user/domain/UserRepository.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/domain/UserRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface UserRepository extends JpaRepository<User, UUID> {
+public interface UserRepository extends JpaRepository<User, UUID>, UserRepositoryCustom {
 
   Optional<User> findByEmail(String email);
 

--- a/mopl-api/src/main/java/io/mopl/api/user/domain/UserRepositoryCustom.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/domain/UserRepositoryCustom.java
@@ -6,7 +6,7 @@ import java.util.UUID;
 public interface UserRepositoryCustom {
 
   /** 사용자 목록을 커서 기반 페이지네이션으로 조회 */
-  UserPage findUserPage(
+  UserPage findUsersPage(
       String emailLike,
       String roleEqual,
       Boolean isLocked,

--- a/mopl-api/src/main/java/io/mopl/api/user/domain/UserRepositoryCustom.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/domain/UserRepositoryCustom.java
@@ -1,0 +1,21 @@
+package io.mopl.api.user.domain;
+
+import io.mopl.api.user.dto.UserPage;
+import java.util.UUID;
+
+public interface UserRepositoryCustom {
+
+  /** 사용자 목록을 커서 기반 페이지네이션으로 조회 */
+  UserPage findUserPage(
+      String emailLike,
+      String roleEqual,
+      Boolean isLocked,
+      String cursor,
+      UUID idAfter,
+      int limit,
+      String sortDirection,
+      String sortBy);
+
+  /** 필터 조건에 해당하는 사용자 총 수 조회 */
+  long countUsers(String emailLike, String roleEqual, Boolean isLocked);
+}

--- a/mopl-api/src/main/java/io/mopl/api/user/domain/UserRepositoryImpl.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/domain/UserRepositoryImpl.java
@@ -6,7 +6,7 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.ComparablePath;
 import com.querydsl.core.types.dsl.StringPath;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import io.lettuce.core.search.arguments.AggregateArgs.SortDirection;
+import io.mopl.api.common.dto.SortDirection;
 import io.mopl.api.user.dto.UserPage;
 import io.mopl.core.error.BusinessException;
 import io.mopl.core.error.CommonErrorCode;
@@ -165,7 +165,7 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
       SortDirection sortDirection) {
 
     // gt = greater than, lt = less then, eq = equal
-    if (sortDirection == SortDirection.DESC) {
+    if (sortDirection == SortDirection.DESCENDING) {
       return field.lt(cursor).or(field.eq(cursor).and(idField.eq(idAfter)));
     }
     return field.gt(cursor).or(field.eq(cursor).and(idField.gt(idAfter)));
@@ -188,7 +188,7 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
           .addDetail("cursor", cursor);
     }
 
-    if (sortDirection == SortDirection.DESC) {
+    if (sortDirection == SortDirection.DESCENDING) {
       return field.lt(c).or(field.eq(c).and(idField.lt(idAfter)));
     }
     return field.gt(c).or(field.eq(c).and(idField.gt(idAfter)));
@@ -211,7 +211,7 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
           .addDetail("cursor", cursor);
     }
 
-    if (sortDirection == SortDirection.DESC) {
+    if (sortDirection == SortDirection.DESCENDING) {
       return field.lt(c).or(field.eq(c).and(idField.lt(idAfter)));
     }
     return field.gt(c).or(field.eq(c).and(idField.gt(idAfter)));
@@ -234,7 +234,7 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
           .addDetail("cursor", cursor);
     }
 
-    if (sortDirection == SortDirection.DESC) {
+    if (sortDirection == SortDirection.DESCENDING) {
       return field.lt(c).or(field.eq(c).and(idField.lt(idAfter)));
     }
     return field.gt(c).or(field.eq(c).and(idField.gt(idAfter)));
@@ -244,12 +244,13 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
   private OrderSpecifier<?> buildPrimaryOrder(SortBy sortBy, SortDirection sortDirection, QUser u) {
 
     return switch (sortBy) {
-      case NAME -> (sortDirection == SortDirection.DESC) ? u.name.desc() : u.name.asc();
-      case EMAIL -> (sortDirection == SortDirection.DESC) ? u.email.desc() : u.email.asc();
+      case NAME -> (sortDirection == SortDirection.DESCENDING) ? u.name.desc() : u.name.asc();
+      case EMAIL -> (sortDirection == SortDirection.DESCENDING) ? u.email.desc() : u.email.asc();
       case CREATED_AT ->
-          (sortDirection == SortDirection.DESC) ? u.createdAt.desc() : u.createdAt.asc();
-      case IS_LOCKED -> (sortDirection == SortDirection.DESC) ? u.locked.desc() : u.locked.asc();
-      case ROLE -> (sortDirection == SortDirection.DESC) ? u.role.desc() : u.role.asc();
+          (sortDirection == SortDirection.DESCENDING) ? u.createdAt.desc() : u.createdAt.asc();
+      case IS_LOCKED ->
+          (sortDirection == SortDirection.DESCENDING) ? u.locked.desc() : u.locked.asc();
+      case ROLE -> (sortDirection == SortDirection.DESCENDING) ? u.role.desc() : u.role.asc();
     };
   }
 
@@ -284,19 +285,11 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
   /** 정렬 방향 */
   private SortDirection parseSortDirection(String value) {
     if (value == null || value.isBlank()) {
-      return SortDirection.DESC;
-    }
-
-    String normalized = value.toUpperCase();
-
-    if ("ASCENDING".equals(normalized)) {
-      return SortDirection.ASC;
-    } else if ("DESCENDING".equals(normalized)) {
-      return SortDirection.DESC;
+      return SortDirection.DESCENDING;
     }
 
     try {
-      return SortDirection.valueOf(normalized);
+      return SortDirection.valueOf(value.toUpperCase());
     } catch (IllegalArgumentException e) {
       throw new BusinessException(CommonErrorCode.INVALID_REQUEST)
           .addDetail("reason", "잘못된 sortDirection 값입니다. ASCENDING 또는 DESCENDING을 사용하세요.")

--- a/mopl-api/src/main/java/io/mopl/api/user/domain/UserRepositoryImpl.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/domain/UserRepositoryImpl.java
@@ -103,7 +103,7 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
     BooleanBuilder where = new BooleanBuilder();
 
     if (emailLike != null && !emailLike.isBlank()) {
-      where.and(u.email.containsIgnoreCase(emailLike));
+      where.and(u.email.containsIgnoreCase(emailLike).or(u.name.containsIgnoreCase(emailLike)));
     }
 
     if (roleEqual != null && !roleEqual.isBlank()) {

--- a/mopl-api/src/main/java/io/mopl/api/user/domain/UserRepositoryImpl.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/domain/UserRepositoryImpl.java
@@ -1,0 +1,278 @@
+package io.mopl.api.user.domain;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.ComparablePath;
+import com.querydsl.core.types.dsl.StringPath;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import io.lettuce.core.search.arguments.AggregateArgs.SortDirection;
+import io.mopl.api.user.dto.UserPage;
+import io.mopl.core.error.BusinessException;
+import io.mopl.core.error.CommonErrorCode;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepositoryCustom {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public UserPage findUsersPage(
+      String emailLike,
+      String roleEqual,
+      Boolean isLocked,
+      String cursor,
+      UUID idAfter,
+      int limit,
+      String sortDirectionRaw,
+      String sortByRaw) {
+
+    SortBy sortBy = SortBy.from(sortByRaw);
+    SortDirection sortDirection = parseSortDirection(sortDirectionRaw);
+
+    QUser u = QUser.user;
+
+    BooleanBuilder where = buildBaseWhere(emailLike, roleEqual, isLocked, u);
+
+    if (cursor != null && !cursor.isBlank()) {
+      if (idAfter == null) {
+        throw new BusinessException(CommonErrorCode.INVALID_REQUEST)
+            .addDetail("reason", "cursor가 있으면 idAfter도 필수입니다.");
+      }
+      BooleanExpression cursorCondition =
+          buildCursorCondition(cursor, idAfter, sortBy, sortDirection, u);
+      where.and(cursorCondition);
+    }
+
+    OrderSpecifier<?> primaryOrder = buildPrimaryOrder(sortBy, sortDirection, u);
+
+    List<User> fetched =
+        queryFactory
+            .selectFrom(u)
+            .where(where)
+            .orderBy(primaryOrder, (sortDirection == SortDirection.DESC) ? u.id.desc() : u.id.asc())
+            .limit(limit + 1)
+            .fetch();
+
+    boolean hasNext = fetched.size() > limit;
+    if (hasNext) {
+      fetched = fetched.subList(0, limit);
+    }
+
+    String nextCursor = null;
+    UUID nextIdAfter = null;
+
+    if (hasNext && !fetched.isEmpty()) {
+      User last = fetched.getLast();
+      nextIdAfter = last.getId();
+
+      switch (sortBy) {
+        case NAME -> nextCursor = last.getName();
+        case EMAIL -> nextCursor = last.getEmail();
+        case CREATED_AT -> nextCursor = String.valueOf(last.getCreatedAt());
+        case IS_LOCKED -> nextCursor = String.valueOf(last.isLocked());
+        case ROLE -> nextCursor = last.getRole().name();
+      }
+    }
+
+    return new UserPage(fetched, hasNext, nextCursor, nextIdAfter);
+  }
+
+  @Override
+  public long countUsers(String emailLike, String roleEqual, Boolean isLocked) {
+    QUser u = QUser.user;
+    BooleanBuilder where = buildBaseWhere(emailLike, roleEqual, isLocked, u);
+
+    Long count = queryFactory.select(u.count()).from(u).where(where).fetchOne();
+
+    return count != null ? count : 0L;
+  }
+
+  // ===== Private Helper 메서드 =====
+
+  /** 기본 필터 조건 구성 */
+  private BooleanBuilder buildBaseWhere(
+      String emailLike, String roleEqual, Boolean isLocked, QUser u) {
+    BooleanBuilder where = new BooleanBuilder();
+
+    if (emailLike != null && !emailLike.isBlank()) {
+      where.and(u.email.containsIgnoreCase(emailLike));
+    }
+
+    if (roleEqual != null && !roleEqual.isBlank()) {
+      try {
+        UserRole role = UserRole.valueOf(roleEqual);
+        where.and(u.role.eq(role));
+      } catch (IllegalArgumentException e) {
+        throw new BusinessException(CommonErrorCode.INVALID_REQUEST)
+            .addDetail("reason", "잘못된 role 값입니다")
+            .addDetail("role", roleEqual);
+      }
+    }
+
+    if (isLocked != null) {
+      where.and(u.locked.eq(isLocked));
+    }
+
+    return where;
+  }
+
+  /** 커서 페이징 조건 구성 */
+  private BooleanExpression buildCursorCondition(
+      String cursor, UUID idAfter, SortBy sortBy, SortDirection sortDirection, QUser u) {
+    return switch (sortBy) {
+      case NAME -> buildStringCursorCondition(cursor, idAfter, u.name, u.id, sortDirection);
+      case EMAIL -> buildStringCursorCondition(cursor, idAfter, u.email, u.id, sortDirection);
+      case CREATED_AT ->
+          buildInstantCursorCondition(cursor, idAfter, u.createdAt, u.id, sortDirection);
+      case IS_LOCKED -> buildBooleanCursorCondition(cursor, idAfter, u.locked, u.id, sortDirection);
+      case ROLE -> buildRoleCursorCondition(cursor, idAfter, u.role, u.id, sortDirection);
+    };
+  }
+
+  /** 문자열 필드 커서 조건 */
+  private BooleanExpression buildStringCursorCondition(
+      String cursor,
+      UUID idAfter,
+      StringPath field,
+      ComparablePath<UUID> idField,
+      SortDirection sortDirection) {
+
+    // gt = greater than, lt = less then, eq = equal
+    if (sortDirection == SortDirection.DESC) {
+      return field.lt(cursor).or(field.eq(cursor).and(idField.eq(idAfter)));
+    }
+    return field.gt(cursor).or(field.eq(cursor).and(idField.gt(idAfter)));
+  }
+
+  /** Instant 필드 커서 조건 */
+  private BooleanExpression buildInstantCursorCondition(
+      String cursor,
+      UUID idAfter,
+      com.querydsl.core.types.dsl.DateTimePath<Instant> field,
+      com.querydsl.core.types.dsl.ComparablePath<UUID> idField,
+      SortDirection sortDirection) {
+
+    Instant c;
+    try {
+      c = Instant.parse(cursor);
+    } catch (DateTimeParseException e) {
+      throw new BusinessException(CommonErrorCode.INVALID_REQUEST)
+          .addDetail("reason", "잘못된 cursor 형식입니다 (Instant 필요)")
+          .addDetail("cursor", cursor);
+    }
+
+    if (sortDirection == SortDirection.DESC) {
+      return field.lt(c).or(field.eq(c).and(idField.lt(idAfter)));
+    }
+    return field.gt(c).or(field.eq(c).and(idField.gt(idAfter)));
+  }
+
+  /** Boolean 필드 커서 조건 */
+  private BooleanExpression buildBooleanCursorCondition(
+      String cursor,
+      UUID idAfter,
+      com.querydsl.core.types.dsl.BooleanPath field,
+      com.querydsl.core.types.dsl.ComparablePath<UUID> idField,
+      SortDirection sortDirection) {
+
+    boolean c;
+    try {
+      c = Boolean.parseBoolean(cursor);
+    } catch (Exception e) {
+      throw new BusinessException(CommonErrorCode.INVALID_REQUEST)
+          .addDetail("reason", "잘못된 cursor 형식입니다 (Boolean 필요)")
+          .addDetail("cursor", cursor);
+    }
+
+    if (sortDirection == SortDirection.DESC) {
+      return field.lt(c).or(field.eq(c).and(idField.lt(idAfter)));
+    }
+    return field.gt(c).or(field.eq(c).and(idField.gt(idAfter)));
+  }
+
+  /** UserRole 필드 커서 조건 */
+  private BooleanExpression buildRoleCursorCondition(
+      String cursor,
+      UUID idAfter,
+      com.querydsl.core.types.dsl.EnumPath<UserRole> field,
+      com.querydsl.core.types.dsl.ComparablePath<UUID> idField,
+      SortDirection sortDirection) {
+
+    UserRole c;
+    try {
+      c = UserRole.valueOf(cursor);
+    } catch (IllegalArgumentException e) {
+      throw new BusinessException(CommonErrorCode.INVALID_REQUEST)
+          .addDetail("reason", "잘못된 cursor 형식입니다 (UserRole 필요)")
+          .addDetail("cursor", cursor);
+    }
+
+    if (sortDirection == SortDirection.DESC) {
+      return field.lt(c).or(field.eq(c).and(idField.lt(idAfter)));
+    }
+    return field.gt(c).or(field.eq(c).and(idField.gt(idAfter)));
+  }
+
+  /** 기본 정렬 컬럼 */
+  private OrderSpecifier<?> buildPrimaryOrder(SortBy sortBy, SortDirection sortDirection, QUser u) {
+
+    return switch (sortBy) {
+      case NAME -> (sortDirection == SortDirection.DESC) ? u.name.desc() : u.name.asc();
+      case EMAIL -> (sortDirection == SortDirection.DESC) ? u.email.desc() : u.email.asc();
+      case CREATED_AT ->
+          (sortDirection == SortDirection.DESC) ? u.createdAt.desc() : u.createdAt.asc();
+      case IS_LOCKED -> (sortDirection == SortDirection.DESC) ? u.locked.desc() : u.locked.asc();
+      case ROLE -> (sortDirection == SortDirection.DESC) ? u.role.desc() : u.role.asc();
+    };
+  }
+
+  // ===== 내부 Enum =====
+
+  /** 정렬 기준 */
+  private enum SortBy {
+    NAME,
+    EMAIL,
+    CREATED_AT,
+    IS_LOCKED,
+    ROLE;
+
+    public static SortBy from(String value) {
+      if (value == null || value.isBlank()) {
+        return CREATED_AT; // 기본값
+      }
+      return switch (value) {
+        case "name" -> NAME;
+        case "email" -> EMAIL;
+        case "createdAt" -> CREATED_AT;
+        case "isLocked" -> IS_LOCKED;
+        case "role" -> ROLE;
+        default ->
+            throw new BusinessException(CommonErrorCode.INVALID_REQUEST)
+                .addDetail("reason", "잘못된 SortBy 값입니다.")
+                .addDetail("sortBy", value);
+      };
+    }
+  }
+
+  /** 정렬 방향 */
+  private SortDirection parseSortDirection(String value) {
+    if (value == null || value.isBlank()) {
+      return SortDirection.DESC;
+    }
+    try {
+      return SortDirection.valueOf(value.toUpperCase());
+    } catch (IllegalArgumentException e) {
+      throw new BusinessException(CommonErrorCode.INVALID_REQUEST)
+          .addDetail("reason", "잘못된 sortDirection 값입니다.")
+          .addDetail("sortDirection", value);
+    }
+  }
+}

--- a/mopl-api/src/main/java/io/mopl/api/user/domain/UserRepositoryImpl.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/domain/UserRepositoryImpl.java
@@ -164,7 +164,7 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
 
     // gt = greater than, lt = less then, eq = equal
     if (sortDirection == SortDirection.DESCENDING) {
-      return field.lt(cursor).or(field.eq(cursor).and(idField.eq(idAfter)));
+      return field.lt(cursor).or(field.eq(cursor).and(idField.gt(idAfter)));
     }
     return field.gt(cursor).or(field.eq(cursor).and(idField.gt(idAfter)));
   }
@@ -187,7 +187,7 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
     }
 
     if (sortDirection == SortDirection.DESCENDING) {
-      return field.lt(c).or(field.eq(c).and(idField.lt(idAfter)));
+      return field.lt(c).or(field.eq(c).and(idField.gt(idAfter)));
     }
     return field.gt(c).or(field.eq(c).and(idField.gt(idAfter)));
   }
@@ -200,17 +200,15 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
       com.querydsl.core.types.dsl.ComparablePath<UUID> idField,
       SortDirection sortDirection) {
 
-    boolean c;
-    try {
-      c = Boolean.parseBoolean(cursor);
-    } catch (Exception e) {
+    if (!"true".equalsIgnoreCase(cursor) && !"false".equalsIgnoreCase(cursor)) {
       throw new BusinessException(CommonErrorCode.INVALID_REQUEST)
           .addDetail("reason", "잘못된 cursor 형식입니다 (Boolean 필요)")
           .addDetail("cursor", cursor);
     }
+    boolean c = Boolean.parseBoolean(cursor);
 
     if (sortDirection == SortDirection.DESCENDING) {
-      return field.lt(c).or(field.eq(c).and(idField.lt(idAfter)));
+      return field.lt(c).or(field.eq(c).and(idField.gt(idAfter)));
     }
     return field.gt(c).or(field.eq(c).and(idField.gt(idAfter)));
   }
@@ -233,7 +231,7 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
     }
 
     if (sortDirection == SortDirection.DESCENDING) {
-      return field.lt(c).or(field.eq(c).and(idField.lt(idAfter)));
+      return field.lt(c).or(field.eq(c).and(idField.gt(idAfter)));
     }
     return field.gt(c).or(field.eq(c).and(idField.gt(idAfter)));
   }

--- a/mopl-api/src/main/java/io/mopl/api/user/domain/UserRepositoryImpl.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/domain/UserRepositoryImpl.java
@@ -267,11 +267,20 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
     if (value == null || value.isBlank()) {
       return SortDirection.DESC;
     }
+
+    String normalized = value.toUpperCase();
+
+    if ("ASCENDING".equals(normalized)) {
+      return SortDirection.ASC;
+    } else if ("DESCENDING".equals(normalized)) {
+      return SortDirection.DESC;
+    }
+
     try {
-      return SortDirection.valueOf(value.toUpperCase());
+      return SortDirection.valueOf(normalized);
     } catch (IllegalArgumentException e) {
       throw new BusinessException(CommonErrorCode.INVALID_REQUEST)
-          .addDetail("reason", "잘못된 sortDirection 값입니다.")
+          .addDetail("reason", "잘못된 sortDirection 값입니다. ASCENDING 또는 DESCENDING을 사용하세요.")
           .addDetail("sortDirection", value);
     }
   }

--- a/mopl-api/src/main/java/io/mopl/api/user/domain/UserRepositoryImpl.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/domain/UserRepositoryImpl.java
@@ -12,6 +12,7 @@ import io.mopl.core.error.BusinessException;
 import io.mopl.core.error.CommonErrorCode;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -57,7 +58,7 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
         queryFactory
             .selectFrom(u)
             .where(where)
-            .orderBy(primaryOrder, (sortDirection == SortDirection.DESC) ? u.id.desc() : u.id.asc())
+            .orderBy(buildOrderSpecifiers(sortBy, sortDirection, u).toArray(new OrderSpecifier[0]))
             .limit(limit + 1)
             .fetch();
 
@@ -83,6 +84,24 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
     }
 
     return new UserPage(fetched, hasNext, nextCursor, nextIdAfter);
+  }
+
+  private List<OrderSpecifier<?>> buildOrderSpecifiers(
+      SortBy sortBy, SortDirection sortDirection, QUser u) {
+
+    List<OrderSpecifier<?>> orders = new ArrayList<>();
+
+    orders.add(buildPrimaryOrder(sortBy, sortDirection, u));
+
+    if (sortBy != SortBy.NAME) {
+      orders.add(u.name.asc());
+    } else {
+      orders.add(u.createdAt.desc());
+    }
+
+    orders.add(u.id.asc());
+
+    return orders;
   }
 
   @Override

--- a/mopl-api/src/main/java/io/mopl/api/user/domain/UserRepositoryImpl.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/domain/UserRepositoryImpl.java
@@ -52,8 +52,6 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
       where.and(cursorCondition);
     }
 
-    OrderSpecifier<?> primaryOrder = buildPrimaryOrder(sortBy, sortDirection, u);
-
     List<User> fetched =
         queryFactory
             .selectFrom(u)

--- a/mopl-api/src/main/java/io/mopl/api/user/dto/CursorResponseUserDto.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/dto/CursorResponseUserDto.java
@@ -1,0 +1,23 @@
+package io.mopl.api.user.dto;
+
+import java.util.List;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CursorResponseUserDto {
+
+  private List<UserDto> data;
+  private String nextCursor;
+  private UUID nextIdAfter;
+  private boolean hasNext;
+  private long totalCount;
+  private String sortBy;
+  private String sortDirection;
+}

--- a/mopl-api/src/main/java/io/mopl/api/user/dto/UserPage.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/dto/UserPage.java
@@ -1,0 +1,17 @@
+package io.mopl.api.user.dto;
+
+import io.mopl.api.user.domain.User;
+import java.util.List;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserPage {
+
+  private final List<User> users;
+  private final boolean hasNext;
+  private final String nextCursor;
+  private final UUID nextIdAfter;
+}

--- a/mopl-api/src/main/java/io/mopl/api/user/dto/UserSearchRequest.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/dto/UserSearchRequest.java
@@ -64,8 +64,14 @@ public class UserSearchRequest {
       if ("createdAt".equals(sort)) {
         Instant.parse(cursor);
         return true;
+      } else if ("isLocked".equals(sort)) {
+        if (!"true".equals(cursor) && !"false".equals(cursor)) {
+          return false;
+        }
+        return true;
+      } else {
+        return !cursor.isBlank();
       }
-      return true;
     } catch (Exception e) {
       return false;
     }

--- a/mopl-api/src/main/java/io/mopl/api/user/dto/UserSearchRequest.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/dto/UserSearchRequest.java
@@ -1,0 +1,73 @@
+package io.mopl.api.user.dto;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserSearchRequest {
+
+  private String emailLike;
+  private String roleEqual; // USER | ADMIN
+  private Boolean isLocked;
+  private String cursor;
+  private UUID idAfter;
+
+  @Min(1)
+  @Max(100)
+  private Integer limit;
+
+  @Pattern(
+      regexp = "^(ASCENDING|DESCENDING)$",
+      message = "정렬 방향은 ASCENDING 이거나 DESCENDING 이어야 합니다.")
+  private String sortDirection;
+
+  @Pattern(
+      regexp = "^(name|email|createdAt|isLocked|role)$",
+      message = "정렬은 name, email, createdAt, isLocked, role 중 하나로만 가능합니다.")
+  private String sortBy;
+
+  // ===== 기본값 제공 메서드 =====
+  public int getLimitOrDefault() {
+    return limit != null ? limit : 20;
+  }
+
+  public String getSortDirectionOrDefault() {
+    return (sortDirection == null || sortDirection.isBlank()) ? "DESCENDING" : sortDirection;
+  }
+
+  public String getSortByOrDefault() {
+    return (sortBy == null || sortBy.isBlank()) ? "createdAt" : sortBy;
+  }
+
+  // ===== 커스텀 Validation =====
+  @AssertTrue(message = "cursor와 idAfter은 둘 다 있거나 둘 다 없어야 합니다.")
+  public boolean isCursorAndIdAfterValid() {
+    boolean hasCursor = cursor != null && !cursor.isBlank();
+    boolean hasIdAfter = idAfter != null;
+    return (hasCursor && hasIdAfter) || (!hasCursor && !hasIdAfter);
+  }
+
+  @AssertTrue(message = "cursor 형식은 sortBy 형식과 매치되어야 합니다.")
+  public boolean isCursorFormatValid() {
+    if (cursor == null || cursor.isBlank()) {
+      return true;
+    }
+    String sort = getSortByOrDefault();
+    try {
+      if ("createdAt".equals(sort)) {
+        Instant.parse(cursor);
+        return true;
+      }
+      return true;
+    } catch (Exception e) {
+      return false;
+    }
+  }
+}

--- a/mopl-api/src/main/java/io/mopl/api/user/dto/UserSearchRequest.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/dto/UserSearchRequest.java
@@ -1,10 +1,8 @@
 package io.mopl.api.user.dto;
 
-import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Pattern;
-import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 import lombok.Setter;
@@ -33,7 +31,6 @@ public class UserSearchRequest {
       message = "정렬은 name, email, createdAt, isLocked, role 중 하나로만 가능합니다.")
   private String sortBy;
 
-  // ===== 기본값 제공 메서드 =====
   public int getLimitOrDefault() {
     return limit != null ? limit : 20;
   }
@@ -44,36 +41,5 @@ public class UserSearchRequest {
 
   public String getSortByOrDefault() {
     return (sortBy == null || sortBy.isBlank()) ? "createdAt" : sortBy;
-  }
-
-  // ===== 커스텀 Validation =====
-  @AssertTrue(message = "cursor와 idAfter은 둘 다 있거나 둘 다 없어야 합니다.")
-  public boolean isCursorAndIdAfterValid() {
-    boolean hasCursor = cursor != null && !cursor.isBlank();
-    boolean hasIdAfter = idAfter != null;
-    return (hasCursor && hasIdAfter) || (!hasCursor && !hasIdAfter);
-  }
-
-  @AssertTrue(message = "cursor 형식은 sortBy 형식과 매치되어야 합니다.")
-  public boolean isCursorFormatValid() {
-    if (cursor == null || cursor.isBlank()) {
-      return true;
-    }
-    String sort = getSortByOrDefault();
-    try {
-      if ("createdAt".equals(sort)) {
-        Instant.parse(cursor);
-        return true;
-      } else if ("isLocked".equals(sort)) {
-        if (!"true".equals(cursor) && !"false".equals(cursor)) {
-          return false;
-        }
-        return true;
-      } else {
-        return !cursor.isBlank();
-      }
-    } catch (Exception e) {
-      return false;
-    }
   }
 }

--- a/mopl-api/src/main/java/io/mopl/api/user/service/UserQueryService.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/service/UserQueryService.java
@@ -1,0 +1,58 @@
+package io.mopl.api.user.service;
+
+import io.mopl.api.user.domain.User;
+import io.mopl.api.user.domain.UserRepository;
+import io.mopl.api.user.dto.CursorResponseUserDto;
+import io.mopl.api.user.dto.UserDto;
+import io.mopl.api.user.dto.UserPage;
+import io.mopl.api.user.dto.UserSearchRequest;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserQueryService {
+
+  private final UserRepository userRepository;
+
+  public CursorResponseUserDto findUsers(UserSearchRequest request) {
+
+    String emailLike = request.getEmailLike();
+    String roleEqual = request.getRoleEqual();
+    Boolean isLocked = request.getIsLocked();
+
+    String cursor = request.getCursor();
+    var idAfter = request.getIdAfter();
+    int limit = request.getLimitOrDefault();
+    String sortDirection = request.getSortDirectionOrDefault();
+    String sortBy = request.getSortByOrDefault();
+
+    UserPage page =
+        userRepository.findUsersPage(
+            emailLike, roleEqual, isLocked, cursor, idAfter, limit, sortDirection, sortBy);
+
+    List<User> users = page.getUsers();
+
+    long totalCount = userRepository.countUsers(emailLike, roleEqual, isLocked);
+
+    List<UserDto> data = new ArrayList<>();
+    for (User user : users) {
+      UserDto dto = UserDto.from(user);
+      data.add(dto);
+    }
+
+    return CursorResponseUserDto.builder()
+        .data(data)
+        .nextCursor(page.getNextCursor())
+        .nextIdAfter(page.getNextIdAfter())
+        .hasNext(page.isHasNext())
+        .totalCount(totalCount)
+        .sortBy(sortBy)
+        .sortDirection(sortDirection)
+        .build();
+  }
+}


### PR DESCRIPTION
## 📌 작업 개요
- 작업 내용: 사용자 목록 조회 API 구현 (ADMIN 전용, 커서 페이지네이션)
- 관련 이슈: 

## 🚀 주요 변경 사항
- [x] 사용자 목록 조회 API 구현

## 🛠 DB 변경 사항
- [ ] MySQL 스키마 변경 여부 (DDL 첨부)
- [ ] Redis 키 구조 변경 여부

## 🧪 테스트 결과 (필수)
> 팀 가이드에 따라 Postman/local 환경에서의 기능 테스트를 완료해야 합니다.

- [x] **테스트 수행 완료**
- **테스트 시나리오:**
각 정렬 정상 작동 및 키워드로 이름+email 동시 검색 기능 확인
- **증빙자료:** (Postman 응답 결과 캡쳐본 첨부 또는 JSON 응답 복사)
<img width="1218" height="878" alt="01  최초 접속 시 이름 오름차순 정렬" src="https://github.com/user-attachments/assets/f50f91a3-e544-4ac5-a181-ca1db319dee2" />
<img width="1218" height="878" alt="02  이름 내림차순 정렬" src="https://github.com/user-attachments/assets/150eb916-9646-4f32-af6f-89f71af8b02f" />
<img width="1218" height="878" alt="03  이메일 오름차순 정렬" src="https://github.com/user-attachments/assets/dd3d1b09-b7a3-4dec-ac54-a639245c8e42" />
<img width="1218" height="878" alt="04  이메일 내림차순 정렬" src="https://github.com/user-attachments/assets/90c2ede3-a0a2-4af2-884a-e50eb43fd196" />
<img width="1218" height="878" alt="05  가입일 오름차순 정렬" src="https://github.com/user-attachments/assets/1bdd34b9-4a7a-45a6-b96b-1702504bccdb" />
<img width="1218" height="878" alt="06  가입일 내림차순 정렬" src="https://github.com/user-attachments/assets/79f388c2-4f9b-47f5-a366-90ef1c9f2c2c" />
<img width="1218" height="878" alt="07  계정 잠금 오름차순 정렬" src="https://github.com/user-attachments/assets/7a24dc3c-374f-4de9-91b8-c4dd19d4bd1c" />
<img width="1218" height="878" alt="08  계정 잠금 내림차순 정렬" src="https://github.com/user-attachments/assets/2b363e53-0535-4810-9dbc-0b04aa62ab07" />
<img width="1218" height="878" alt="09  ADMIN 오름차순 정렬" src="https://github.com/user-attachments/assets/b1bb3fb9-a3db-447e-a509-010c765fdeb1" />
<img width="1218" height="878" alt="10  ADMIN 내림차순 정렬" src="https://github.com/user-attachments/assets/8bbb217e-4c43-432a-9a83-344411b422bf" />
<img width="1218" height="878" alt="11  검색 1" src="https://github.com/user-attachments/assets/b8a43e4a-0e63-4c97-a48d-87c303f94058" />
<img width="1218" height="878" alt="12  검색 2" src="https://github.com/user-attachments/assets/0e055199-8114-45e3-9045-2e183bd2c2cd" />

## ✅ 체크리스트
- [x] 코드 컨벤션(Checkstyle/Spotless)을 준수했는가?
- [x] 빌드가 성공적으로 수행되는가? (`./gradlew build`)
- [x] 불필요한 주석이나 print문은 제거했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 관리자 전용 사용자 목록 조회 API가 추가되었습니다. 이메일·역할·잠금 상태로 필터링 가능하며 커서 기반 페이지네이션과 다중 정렬을 지원합니다.
  * 페이징·정렬 정보(다음 커서, 다음 ID, 더보기 여부, 전체 카운트)를 포함한 응답 형식과 검색 요청 파라미터가 도입되었습니다.
  * 서버측 조회 로직 및 페이징 처리 서비스가 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->