### PR TITLE
사용자 계정 잠금 API 구현

### DIFF
--- a/mopl-api/src/main/java/io/mopl/api/auth/jwt/JwtAuthenticationFilter.java
+++ b/mopl-api/src/main/java/io/mopl/api/auth/jwt/JwtAuthenticationFilter.java
@@ -13,11 +13,11 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -28,7 +28,6 @@ import org.springframework.security.web.authentication.WebAuthenticationDetailsS
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
-import tools.jackson.databind.json.JsonMapper;
 
 @Slf4j
 @Component
@@ -36,10 +35,9 @@ import tools.jackson.databind.json.JsonMapper;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   private final JwtTokenProvider jwtTokenProvider;
-  private final RedisTemplate<String, Boolean> redisTemplate;
-  private final UserRepository userRepository;
+  private final RedisTemplate<String, String> redisTemplate;
   private final MessageSource messageSource;
-  private final JsonMapper objectMapper;
+  private final ApplicationContext applicationContext;
 
   @Override
   protected void doFilterInternal(
@@ -87,12 +85,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     response.setContentType("application/json");
     response.setCharacterEncoding("UTF-8");
 
-    Map<String, String> errorResponse =
-        Map.of(
-            "exceptionName", ((Enum<?>) e.getErrorCode()).name(),
-            "message", resolveMessage(e.getErrorCode().getMessageKey()));
+    String exceptionName = ((Enum<?>) e.getErrorCode()).name();
 
-    objectMapper.writeValue(response.getWriter(), errorResponse);
+    String message = resolveMessage(e.getErrorCode().getMessageKey());
+
+    String jsonResponse =
+        String.format(
+            "{\"exceptionName\":\"%s\",\"message\":\"%s\"}", exceptionName, escapeJson(message));
+
+    response.getWriter().write(jsonResponse);
   }
 
   /** MessageSource로 메시지 resolve */
@@ -104,12 +105,27 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
   }
 
+  /** JSON 특수문자 이스케이프 */
+  private String escapeJson(String value) {
+    if (value == null) {
+      return "";
+    }
+    return value
+        .replace("\\", "\\\\")
+        .replace("\"", "\\\"")
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t");
+  }
+
   /** Redis에서 계정 잠금 상태 확인 */
   private void checkUserLocked(UUID userId) {
     String redisKey = RedisKeyPrefix.USER_LOCKED + userId;
-    Boolean isLocked = redisTemplate.opsForValue().get(redisKey);
+    String lockedValue = redisTemplate.opsForValue().get(redisKey);
 
-    if (isLocked == null) {
+    Boolean isLocked;
+    if (lockedValue == null) {
+      UserRepository userRepository = applicationContext.getBean(UserRepository.class);
       User user =
           userRepository
               .findById(userId)
@@ -121,8 +137,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
           .opsForValue()
           .set(
               redisKey,
-              isLocked,
+              String.valueOf(isLocked),
               Duration.ofSeconds(jwtTokenProvider.getAccessTokenValidityInSeconds()));
+    } else {
+      // String을 Boolean으로 변환
+      isLocked = Boolean.valueOf(lockedValue);
     }
 
     if (Boolean.TRUE.equals(isLocked)) {

--- a/mopl-api/src/main/java/io/mopl/api/auth/jwt/JwtAuthenticationFilter.java
+++ b/mopl-api/src/main/java/io/mopl/api/auth/jwt/JwtAuthenticationFilter.java
@@ -17,7 +17,7 @@ import java.util.UUID;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.ApplicationContext;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -37,7 +37,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   private final JwtTokenProvider jwtTokenProvider;
   private final RedisTemplate<String, String> redisTemplate;
   private final MessageSource messageSource;
-  private final ApplicationContext applicationContext;
+
+  private final ObjectProvider<UserRepository> userRepositoryProvider;
 
   @Override
   protected void doFilterInternal(
@@ -120,12 +121,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   /** Redis에서 계정 잠금 상태 확인 */
   private void checkUserLocked(UUID userId) {
+    UserRepository userRepository = userRepositoryProvider.getObject();
+
     String redisKey = RedisKeyPrefix.USER_LOCKED + userId;
     String lockedValue = redisTemplate.opsForValue().get(redisKey);
 
     Boolean isLocked;
     if (lockedValue == null) {
-      UserRepository userRepository = applicationContext.getBean(UserRepository.class);
       User user =
           userRepository
               .findById(userId)
@@ -133,12 +135,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
       isLocked = user.isLocked();
 
-      redisTemplate
-          .opsForValue()
-          .set(
-              redisKey,
-              String.valueOf(isLocked),
-              Duration.ofSeconds(jwtTokenProvider.getAccessTokenValidityInSeconds()));
+      redisTemplate.opsForValue().set(redisKey, String.valueOf(isLocked), Duration.ofHours(24));
     } else {
       // String을 Boolean으로 변환
       isLocked = Boolean.valueOf(lockedValue);

--- a/mopl-api/src/main/java/io/mopl/api/auth/jwt/JwtAuthenticationFilter.java
+++ b/mopl-api/src/main/java/io/mopl/api/auth/jwt/JwtAuthenticationFilter.java
@@ -13,6 +13,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,7 @@ import org.springframework.security.web.authentication.WebAuthenticationDetailsS
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
+import tools.jackson.databind.ObjectMapper;
 
 @Slf4j
 @Component
@@ -37,6 +39,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   private final RedisTemplate<String, Boolean> redisTemplate;
   private final UserRepository userRepository;
   private final MessageSource messageSource;
+  private final ObjectMapper objectMapper;
 
   @Override
   protected void doFilterInternal(
@@ -80,19 +83,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   /** Filter에서 에러 응답 직접 작성 (MessageSource 사용) */
   private void sendErrorResponse(HttpServletResponse response, BusinessException e)
       throws IOException {
-    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
+    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
     response.setContentType("application/json");
     response.setCharacterEncoding("UTF-8");
 
-    String exceptionName = ((Enum<?>) e.getErrorCode()).name();
+    Map<String, String> errorResponse =
+        Map.of(
+            "exceptionName", ((Enum<?>) e.getErrorCode()).name(),
+            "message", resolveMessage(e.getErrorCode().getMessageKey()));
 
-    String message = resolveMessage(e.getErrorCode().getMessageKey());
-
-    String jsonResponse =
-        String.format(
-            "{\"exceptionName\":\"%s\",\"message\":\"%s\"}", exceptionName, escapeJson(message));
-
-    response.getWriter().write(jsonResponse);
+    objectMapper.writeValue(response.getWriter(), errorResponse);
   }
 
   /** MessageSource로 메시지 resolve */
@@ -102,19 +102,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     } catch (Exception e) {
       return messageKey;
     }
-  }
-
-  /** JSON 특수문자 이스케이프 */
-  private String escapeJson(String value) {
-    if (value == null) {
-      return "";
-    }
-    return value
-        .replace("\\", "\\\\")
-        .replace("\"", "\\\"")
-        .replace("\n", "\\n")
-        .replace("\r", "\\r")
-        .replace("\t", "\\t");
   }
 
   /** Redis에서 계정 잠금 상태 확인 */

--- a/mopl-api/src/main/java/io/mopl/api/auth/jwt/JwtAuthenticationFilter.java
+++ b/mopl-api/src/main/java/io/mopl/api/auth/jwt/JwtAuthenticationFilter.java
@@ -2,7 +2,6 @@ package io.mopl.api.auth.jwt;
 
 import io.mopl.api.common.config.AuthUser;
 import io.mopl.api.common.error.AuthErrorCode;
-import io.mopl.api.common.error.UserErrorCode;
 import io.mopl.api.user.domain.User;
 import io.mopl.api.user.domain.UserRepository;
 import io.mopl.core.error.BusinessException;
@@ -18,6 +17,8 @@ import java.util.UUID;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -35,6 +36,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   private final JwtTokenProvider jwtTokenProvider;
   private final RedisTemplate<String, Boolean> redisTemplate;
   private final UserRepository userRepository;
+  private final MessageSource messageSource;
 
   @Override
   protected void doFilterInternal(
@@ -51,6 +53,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String email = jwtTokenProvider.getEmail(token);
         String role = jwtTokenProvider.getRole(token);
 
+        // Redis에서 계정 잠금 상태 확인
+        checkUserLocked(userId);
+
         AuthUser authUser = AuthUser.builder().userId(userId).email(email).role(role).build();
 
         UsernamePasswordAuthenticationToken authentication =
@@ -63,6 +68,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         log.debug("JWT 인증 성공: userId={}, email={}, role={}", userId, email, role);
       }
+    } catch (BusinessException e) {
+      log.warn("계정 잠금 상태로 인한 요청 차단: {}", e.getMessage());
+      sendErrorResponse(response, e);
+      return;
     } catch (Exception e) {
       log.error("JWT 인증 실패: {}", e.getMessage());
     }
@@ -70,15 +79,44 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     filterChain.doFilter(request, response);
   }
 
-  /** Request Header에서 Bearer 토큰 추출 */
-  private String getTokenFromRequest(HttpServletRequest request) {
-    String bearerToken = request.getHeader("Authorization");
+  /** Filter에서 에러 응답 직접 작성 (MessageSource 사용) */
+  private void sendErrorResponse(HttpServletResponse response, BusinessException e)
+      throws IOException {
+    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
+    response.setContentType("application/json");
+    response.setCharacterEncoding("UTF-8");
 
-    if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
-      return bearerToken.substring(7);
+    String exceptionName = ((Enum<?>) e.getErrorCode()).name();
+
+    String message = resolveMessage(e.getErrorCode().getMessageKey());
+
+    String jsonResponse =
+        String.format(
+            "{\"exceptionName\":\"%s\",\"message\":\"%s\"}", exceptionName, escapeJson(message));
+
+    response.getWriter().write(jsonResponse);
+  }
+
+  /** MessageSource로 메시지 resolve */
+  private String resolveMessage(String messageKey) {
+    try {
+      return messageSource.getMessage(messageKey, null, LocaleContextHolder.getLocale());
+    } catch (Exception e) {
+      return messageKey;
     }
+  }
 
-    return null;
+  /** JSON 특수문자 이스케이프 */
+  private String escapeJson(String value) {
+    if (value == null) {
+      return "";
+    }
+    return value
+        .replace("\\", "\\\\")
+        .replace("\"", "\\\"")
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t");
   }
 
   /** Redis에서 계정 잠금 상태 확인 */
@@ -90,7 +128,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
       User user =
           userRepository
               .findById(userId)
-              .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+              .orElseThrow(() -> new BusinessException(AuthErrorCode.USER_NOT_FOUND));
 
       isLocked = user.isLocked();
 
@@ -105,5 +143,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     if (Boolean.TRUE.equals(isLocked)) {
       throw new BusinessException(AuthErrorCode.ACCOUNT_LOCKED);
     }
+  }
+
+  /** Request Header에서 Bearer 토큰 추출 */
+  private String getTokenFromRequest(HttpServletRequest request) {
+    String bearerToken = request.getHeader("Authorization");
+
+    if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+      return bearerToken.substring(7);
+    }
+
+    return null;
   }
 }

--- a/mopl-api/src/main/java/io/mopl/api/auth/jwt/JwtAuthenticationFilter.java
+++ b/mopl-api/src/main/java/io/mopl/api/auth/jwt/JwtAuthenticationFilter.java
@@ -65,8 +65,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 
         SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        log.debug("JWT 인증 성공: userId={}, email={}, role={}", userId, email, role);
       }
     } catch (BusinessException e) {
       log.warn("계정 잠금 상태로 인한 요청 차단: {}", e.getMessage());

--- a/mopl-api/src/main/java/io/mopl/api/auth/jwt/JwtAuthenticationFilter.java
+++ b/mopl-api/src/main/java/io/mopl/api/auth/jwt/JwtAuthenticationFilter.java
@@ -1,6 +1,5 @@
 package io.mopl.api.auth.jwt;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.mopl.api.common.config.AuthUser;
 import io.mopl.api.common.error.AuthErrorCode;
 import io.mopl.api.user.domain.User;
@@ -29,6 +28,7 @@ import org.springframework.security.web.authentication.WebAuthenticationDetailsS
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
+import tools.jackson.databind.json.JsonMapper;
 
 @Slf4j
 @Component
@@ -39,7 +39,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   private final RedisTemplate<String, Boolean> redisTemplate;
   private final UserRepository userRepository;
   private final MessageSource messageSource;
-  private final ObjectMapper objectMapper;
+  private final JsonMapper objectMapper;
 
   @Override
   protected void doFilterInternal(
@@ -70,11 +70,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         SecurityContextHolder.getContext().setAuthentication(authentication);
       }
     } catch (BusinessException e) {
-      log.warn("계정 잠금 상태로 인한 요청 차단: {}", e.getMessage());
+      log.warn("계정 잠금 상태로 인한 요청 차단");
       sendErrorResponse(response, e);
       return;
     } catch (Exception e) {
-      log.error("JWT 인증 실패: {}", e.getMessage());
+      log.error("JWT 인증 실패");
     }
 
     filterChain.doFilter(request, response);

--- a/mopl-api/src/main/java/io/mopl/api/auth/jwt/JwtAuthenticationFilter.java
+++ b/mopl-api/src/main/java/io/mopl/api/auth/jwt/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package io.mopl.api.auth.jwt;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.mopl.api.common.config.AuthUser;
 import io.mopl.api.common.error.AuthErrorCode;
 import io.mopl.api.user.domain.User;
@@ -28,7 +29,6 @@ import org.springframework.security.web.authentication.WebAuthenticationDetailsS
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
-import tools.jackson.databind.ObjectMapper;
 
 @Slf4j
 @Component

--- a/mopl-api/src/main/java/io/mopl/api/auth/jwt/JwtAuthenticationFilter.java
+++ b/mopl-api/src/main/java/io/mopl/api/auth/jwt/JwtAuthenticationFilter.java
@@ -1,16 +1,24 @@
 package io.mopl.api.auth.jwt;
 
 import io.mopl.api.common.config.AuthUser;
+import io.mopl.api.common.error.AuthErrorCode;
+import io.mopl.api.common.error.UserErrorCode;
+import io.mopl.api.user.domain.User;
+import io.mopl.api.user.domain.UserRepository;
+import io.mopl.core.error.BusinessException;
+import io.mopl.redis.constants.RedisKeyPrefix;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -25,6 +33,8 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   private final JwtTokenProvider jwtTokenProvider;
+  private final RedisTemplate<String, Boolean> redisTemplate;
+  private final UserRepository userRepository;
 
   @Override
   protected void doFilterInternal(
@@ -69,5 +79,31 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     return null;
+  }
+
+  /** Redis에서 계정 잠금 상태 확인 */
+  private void checkUserLocked(UUID userId) {
+    String redisKey = RedisKeyPrefix.USER_LOCKED + userId;
+    Boolean isLocked = redisTemplate.opsForValue().get(redisKey);
+
+    if (isLocked == null) {
+      User user =
+          userRepository
+              .findById(userId)
+              .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+      isLocked = user.isLocked();
+
+      redisTemplate
+          .opsForValue()
+          .set(
+              redisKey,
+              isLocked,
+              Duration.ofSeconds(jwtTokenProvider.getAccessTokenValidityInSeconds()));
+    }
+
+    if (Boolean.TRUE.equals(isLocked)) {
+      throw new BusinessException(AuthErrorCode.ACCOUNT_LOCKED);
+    }
   }
 }

--- a/mopl-api/src/main/java/io/mopl/api/auth/jwt/JwtTokenProvider.java
+++ b/mopl-api/src/main/java/io/mopl/api/auth/jwt/JwtTokenProvider.java
@@ -27,6 +27,7 @@ public class JwtTokenProvider {
   @Value("${jwt.secret}")
   private String secret;
 
+  @Getter
   @Value("${jwt.access-token-validity-in-seconds}")
   private long accessTokenValidityInSeconds;
 

--- a/mopl-api/src/main/java/io/mopl/api/user/controller/UserController.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/controller/UserController.java
@@ -52,7 +52,7 @@ public class UserController {
   /** 사용자 계정 잠금 */
   @PatchMapping("/{userId}/locked")
   @PreAuthorize("hasRole('ADMIN')")
-  public ResponseEntity<UserLockUpdateRequest> lockUser(
+  public ResponseEntity<Void> lockUser(
       @PathVariable UUID userId, @Valid @RequestBody UserLockUpdateRequest request) {
     userService.lockUser(userId, request);
     return ResponseEntity.noContent().build();

--- a/mopl-api/src/main/java/io/mopl/api/user/controller/UserController.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/controller/UserController.java
@@ -5,6 +5,7 @@ import io.mopl.api.user.dto.ChangePasswordRequest;
 import io.mopl.api.user.dto.CursorResponseUserDto;
 import io.mopl.api.user.dto.UserCreateRequest;
 import io.mopl.api.user.dto.UserDto;
+import io.mopl.api.user.dto.UserLockUpdateRequest;
 import io.mopl.api.user.dto.UserSearchRequest;
 import io.mopl.api.user.dto.UserUpdateRequest;
 import io.mopl.api.user.service.UserQueryService;
@@ -39,6 +40,7 @@ public class UserController {
   private final UserService userService;
   private final UserQueryService userQueryService;
 
+  // ========== ADMIN 전용 API ==========
   /** 사용자 목록 조회 */
   @GetMapping
   @PreAuthorize("hasRole('ADMIN')")
@@ -47,6 +49,33 @@ public class UserController {
     return ResponseEntity.ok(response);
   }
 
+  /** 사용자 계정 잠금 */
+  @PatchMapping("/{userId}/locked")
+  @PreAuthorize("hasRole('ADMIN')")
+  public ResponseEntity<UserLockUpdateRequest> lockUser(
+      @PathVariable UUID userId, @Valid @RequestBody UserLockUpdateRequest request) {
+    userService.lockUser(userId, request);
+    return ResponseEntity.noContent().build();
+  }
+
+  // ========== USER 전용 API ==========
+  /** 프로필 변경 */
+  @PatchMapping(value = "/{userId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ResponseEntity<UserDto> updateProfile(
+      @PathVariable UUID userId,
+      @RequestPart("request") @Valid UserUpdateRequest request,
+      @RequestPart(value = "image", required = false) MultipartFile profileImage,
+      @AuthenticationPrincipal AuthUser authUser) {
+
+    if (!userId.equals(authUser.getUserId())) {
+      throw new BusinessException(CommonErrorCode.FORBIDDEN);
+    }
+
+    UserDto response = userService.updateProfile(userId, request, profileImage);
+    return ResponseEntity.ok(response);
+  }
+
+  // ========== 전체 API ==========
   /** 회원가입 */
   @PostMapping
   public ResponseEntity<UserDto> createUser(@Valid @RequestBody UserCreateRequest request) {
@@ -74,21 +103,5 @@ public class UserController {
 
     userService.changePassword(userId, request);
     return ResponseEntity.noContent().build();
-  }
-
-  /** 프로필 변경 */
-  @PatchMapping(value = "/{userId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-  public ResponseEntity<UserDto> updateProfile(
-      @PathVariable UUID userId,
-      @RequestPart("request") @Valid UserUpdateRequest request,
-      @RequestPart(value = "image", required = false) MultipartFile profileImage,
-      @AuthenticationPrincipal AuthUser authUser) {
-
-    if (!userId.equals(authUser.getUserId())) {
-      throw new BusinessException(CommonErrorCode.FORBIDDEN);
-    }
-
-    UserDto response = userService.updateProfile(userId, request, profileImage);
-    return ResponseEntity.ok(response);
   }
 }

--- a/mopl-api/src/main/java/io/mopl/api/user/domain/User.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/domain/User.java
@@ -60,6 +60,7 @@ public class User {
   @Enumerated(EnumType.STRING)
   private UserRole role;
 
+  @Setter
   @Column(nullable = false)
   @Builder.Default
   private boolean locked = false;

--- a/mopl-api/src/main/java/io/mopl/api/user/dto/UserLockUpdateRequest.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/dto/UserLockUpdateRequest.java
@@ -13,7 +13,7 @@ import lombok.Setter;
 public class UserLockUpdateRequest {
 
   @NotNull(message = "잠금 상태는 필수입니다")
-  private boolean locked;
+  private Boolean locked;
 
   public boolean getLocked() {
     return locked;

--- a/mopl-api/src/main/java/io/mopl/api/user/dto/UserLockUpdateRequest.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/dto/UserLockUpdateRequest.java
@@ -14,8 +14,4 @@ public class UserLockUpdateRequest {
 
   @NotNull(message = "잠금 상태는 필수입니다")
   private Boolean locked;
-
-  public boolean getLocked() {
-    return locked;
-  }
 }

--- a/mopl-api/src/main/java/io/mopl/api/user/dto/UserLockUpdateRequest.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/dto/UserLockUpdateRequest.java
@@ -1,5 +1,6 @@
 package io.mopl.api.user.dto;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,5 +12,6 @@ import lombok.Setter;
 @AllArgsConstructor
 public class UserLockUpdateRequest {
 
+  @NotNull(message = "잠금 상태는 필수입니다")
   private boolean locked;
 }

--- a/mopl-api/src/main/java/io/mopl/api/user/dto/UserLockUpdateRequest.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/dto/UserLockUpdateRequest.java
@@ -14,4 +14,8 @@ public class UserLockUpdateRequest {
 
   @NotNull(message = "잠금 상태는 필수입니다")
   private boolean locked;
+
+  public boolean getLocked() {
+    return locked;
+  }
 }

--- a/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
@@ -13,7 +13,9 @@ import io.mopl.api.user.dto.UserLockUpdateRequest;
 import io.mopl.api.user.dto.UserSummary;
 import io.mopl.api.user.dto.UserUpdateRequest;
 import io.mopl.core.error.BusinessException;
+import io.mopl.core.error.CommonErrorCode;
 import io.mopl.redis.constants.RedisKeyPrefix;
+import java.time.Duration;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -149,37 +151,38 @@ public class UserService {
     user.setLocked(request.getLocked());
 
     String redisKey = RedisKeyPrefix.USER_LOCKED + userId;
-    boolean redisSuccess = deleteRedisKeyWithRetry(redisKey, 3);
+    String newRedisKey = String.valueOf(request.getLocked());
+
+    boolean redisSuccess = setRedisKeyWithRetry(redisKey, newRedisKey, Duration.ofHours(24), 3);
 
     if (!redisSuccess) {
-      log.error("@@@ CRITICAL: Redis 캐시 삭제 실패 (3회 재시도)");
-    }
-
-    if (Boolean.TRUE.equals(request.getLocked())) {
-      try {
-        refreshTokenService.deleteRefreshToken(userId);
-      } catch (Exception e) {
-        log.error("Refresh Token 삭제 실패");
+      if (Boolean.TRUE.equals(request.getLocked())) {
+        log.error("@@@ CRITICAL: 계정 잠금 시 Redis Key 갱신 실패 - 트랜잭션 롤백");
+        throw new BusinessException(CommonErrorCode.INTERNAL_SERVER_ERROR);
+      } else {
+        log.error("@@@ WARNING: 계정 잠금해제 시 Redis Key 갱신 실패 - DB는 정상 처리, 최대 24시간 후 복구");
       }
     }
   }
 
-  /** Redis 키 삭제 (재시도 로직 포함) */
-  private boolean deleteRedisKeyWithRetry(String redisKey, int maxAttempts) {
+  private boolean setRedisKeyWithRetry(
+      String redisKey, String newRedisKey, Duration ttl, int maxAttempts) {
     for (int attempt = 1; attempt <= maxAttempts; attempt++) {
       try {
-        redisTemplate.delete(redisKey);
+        redisTemplate.opsForValue().set(redisKey, newRedisKey, ttl);
         return true;
       } catch (Exception e) {
         if (attempt == maxAttempts) {
-          log.error("Redis Key 삭제 최종 실패: key = {}", redisKey);
+          log.error("Redis Key 설정 최종 실패: Key = {}", redisKey);
           return false;
         }
+        log.warn("Redis Key 설정 실패, 재시도 중 {}/{}", attempt, maxAttempts);
+
         try {
-          Thread.sleep(100L * attempt);
+          Thread.sleep(100 * attempt);
         } catch (InterruptedException ie) {
           Thread.currentThread().interrupt();
-          log.error("Redis Key 삭제 재시도 중단됨: key = {}", redisKey);
+          log.error("Redis Key 재설정 중단됨");
           return false;
         }
       }

--- a/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
@@ -15,7 +15,6 @@ import io.mopl.api.user.dto.UserSummary;
 import io.mopl.api.user.dto.UserUpdateRequest;
 import io.mopl.core.error.BusinessException;
 import io.mopl.redis.constants.RedisKeyPrefix;
-import java.time.Duration;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -153,22 +152,14 @@ public class UserService {
 
     try {
       String redisKey = RedisKeyPrefix.USER_LOCKED + userId;
-      redisTemplate
-          .opsForValue()
-          .set(
-              redisKey,
-              String.valueOf(request.getLocked()),
-              Duration.ofSeconds(jwtTokenProvider.getAccessTokenValidityInSeconds()));
+
+      redisTemplate.delete(redisKey);
 
       if (Boolean.TRUE.equals(request.getLocked())) {
         refreshTokenService.deleteRefreshToken(userId);
       }
     } catch (Exception e) {
-      log.error(
-          "Redis 업데이트 실패 (DB는 정상 처리됨, 다음 인증 시 자동 복구): userId={}, locked={}",
-          userId,
-          request.getLocked(),
-          e);
+      log.error("캐시 무효화 실패 (DB는 정상 처리됨, TTL 만료 시 자동 복구)", e);
     }
   }
 }

--- a/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
@@ -1,5 +1,6 @@
 package io.mopl.api.user.service;
 
+import io.mopl.api.auth.service.RefreshTokenService;
 import io.mopl.api.common.error.UserErrorCode;
 import io.mopl.api.user.domain.AuthProvider;
 import io.mopl.api.user.domain.User;
@@ -8,6 +9,7 @@ import io.mopl.api.user.domain.UserRole;
 import io.mopl.api.user.dto.ChangePasswordRequest;
 import io.mopl.api.user.dto.UserCreateRequest;
 import io.mopl.api.user.dto.UserDto;
+import io.mopl.api.user.dto.UserLockUpdateRequest;
 import io.mopl.api.user.dto.UserSummary;
 import io.mopl.api.user.dto.UserUpdateRequest;
 import io.mopl.core.error.BusinessException;
@@ -28,6 +30,7 @@ public class UserService {
   private final UserRepository userRepository;
   private final PasswordEncoder passwordEncoder;
   private final ProfileImageUploadService profileImageUploadService;
+  private final RefreshTokenService refreshTokenService;
 
   /** 회원가입 */
   @Transactional
@@ -130,5 +133,20 @@ public class UserService {
     User savedUser = userRepository.save(user);
 
     return UserDto.from(savedUser);
+  }
+
+  /** 계정 잠금 상태 변경 */
+  @Transactional
+  public void lockUser(UUID userId, UserLockUpdateRequest request) {
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+    user.setLocked(request.getLocked());
+
+    if (request.getLocked()) {
+      refreshTokenService.deleteRefreshToken(userId);
+    }
   }
 }

--- a/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
@@ -1,6 +1,5 @@
 package io.mopl.api.user.service;
 
-import io.mopl.api.auth.jwt.JwtTokenProvider;
 import io.mopl.api.auth.service.RefreshTokenService;
 import io.mopl.api.common.error.UserErrorCode;
 import io.mopl.api.user.domain.AuthProvider;
@@ -35,7 +34,6 @@ public class UserService {
   private final ProfileImageUploadService profileImageUploadService;
   private final RefreshTokenService refreshTokenService;
   private final RedisTemplate<String, String> redisTemplate;
-  private final JwtTokenProvider jwtTokenProvider;
 
   /** 회원가입 */
   @Transactional

--- a/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
@@ -35,7 +35,7 @@ public class UserService {
   private final PasswordEncoder passwordEncoder;
   private final ProfileImageUploadService profileImageUploadService;
   private final RefreshTokenService refreshTokenService;
-  private final RedisTemplate<Object, Object> redisTemplate;
+  private final RedisTemplate<String, Boolean> redisTemplate;
   private final JwtTokenProvider jwtTokenProvider;
 
   /** 회원가입 */

--- a/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
@@ -162,7 +162,6 @@ public class UserService {
 
       if (Boolean.TRUE.equals(request.getLocked())) {
         refreshTokenService.deleteRefreshToken(userId);
-      } else {
       }
     } catch (Exception e) {
       log.error(

--- a/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
@@ -1,5 +1,6 @@
 package io.mopl.api.user.service;
 
+import io.mopl.api.auth.jwt.JwtTokenProvider;
 import io.mopl.api.auth.service.RefreshTokenService;
 import io.mopl.api.common.error.UserErrorCode;
 import io.mopl.api.user.domain.AuthProvider;
@@ -13,10 +14,13 @@ import io.mopl.api.user.dto.UserLockUpdateRequest;
 import io.mopl.api.user.dto.UserSummary;
 import io.mopl.api.user.dto.UserUpdateRequest;
 import io.mopl.core.error.BusinessException;
+import io.mopl.redis.constants.RedisKeyPrefix;
+import java.time.Duration;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,6 +35,8 @@ public class UserService {
   private final PasswordEncoder passwordEncoder;
   private final ProfileImageUploadService profileImageUploadService;
   private final RefreshTokenService refreshTokenService;
+  private final RedisTemplate<Object, Object> redisTemplate;
+  private final JwtTokenProvider jwtTokenProvider;
 
   /** 회원가입 */
   @Transactional
@@ -145,7 +151,15 @@ public class UserService {
 
     user.setLocked(request.getLocked());
 
-    if (request.getLocked()) {
+    String redisKey = RedisKeyPrefix.USER_LOCKED + userId;
+    redisTemplate
+        .opsForValue()
+        .set(
+            redisKey,
+            request.getLocked(),
+            Duration.ofSeconds(jwtTokenProvider.getAccessTokenValidityInSeconds()));
+
+    if (Boolean.TRUE.equals(request.getLocked())) {
       refreshTokenService.deleteRefreshToken(userId);
     }
   }

--- a/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
@@ -148,16 +148,42 @@ public class UserService {
 
     user.setLocked(request.getLocked());
 
-    try {
-      String redisKey = RedisKeyPrefix.USER_LOCKED + userId;
+    String redisKey = RedisKeyPrefix.USER_LOCKED + userId;
+    boolean redisSuccess = deleteRedisKeyWithRetry(redisKey, 3);
 
-      redisTemplate.delete(redisKey);
-
-      if (Boolean.TRUE.equals(request.getLocked())) {
-        refreshTokenService.deleteRefreshToken(userId);
-      }
-    } catch (Exception e) {
-      log.error("캐시 무효화 실패 (DB는 정상 처리됨, TTL 만료 시 자동 복구)", e);
+    if (!redisSuccess) {
+      log.error("@@@ CRITICAL: Redis 캐시 삭제 실패 (3회 재시도)");
     }
+
+    if (Boolean.TRUE.equals(request.getLocked())) {
+      try {
+        refreshTokenService.deleteRefreshToken(userId);
+      } catch (Exception e) {
+        log.error("Refresh Token 삭제 실패");
+      }
+    }
+  }
+
+  /** Redis 키 삭제 (재시도 로직 포함) */
+  private boolean deleteRedisKeyWithRetry(String redisKey, int maxAttempts) {
+    for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        redisTemplate.delete(redisKey);
+        return true;
+      } catch (Exception e) {
+        if (attempt == maxAttempts) {
+          log.error("Redis Key 삭제 최종 실패: key = {}", redisKey);
+          return false;
+        }
+        try {
+          Thread.sleep(100 * attempt);
+        } catch (InterruptedException ie) {
+          Thread.currentThread().interrupt();
+          log.error("Redis Key 삭제 재시도 중단됨: key = {}", redisKey);
+          return false;
+        }
+      }
+    }
+    return false;
   }
 }

--- a/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
@@ -151,16 +151,25 @@ public class UserService {
 
     user.setLocked(request.getLocked());
 
-    String redisKey = RedisKeyPrefix.USER_LOCKED + userId;
-    redisTemplate
-        .opsForValue()
-        .set(
-            redisKey,
-            request.getLocked(),
-            Duration.ofSeconds(jwtTokenProvider.getAccessTokenValidityInSeconds()));
+    try {
+      String redisKey = RedisKeyPrefix.USER_LOCKED + userId;
+      redisTemplate
+          .opsForValue()
+          .set(
+              redisKey,
+              request.getLocked(),
+              Duration.ofSeconds(jwtTokenProvider.getAccessTokenValidityInSeconds()));
 
-    if (Boolean.TRUE.equals(request.getLocked())) {
-      refreshTokenService.deleteRefreshToken(userId);
+      if (Boolean.TRUE.equals(request.getLocked())) {
+        refreshTokenService.deleteRefreshToken(userId);
+      } else {
+      }
+    } catch (Exception e) {
+      log.error(
+          "Redis 업데이트 실패 (DB는 정상 처리됨, 다음 인증 시 자동 복구): userId={}, locked={}",
+          userId,
+          request.getLocked(),
+          e);
     }
   }
 }

--- a/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
@@ -163,7 +163,8 @@ public class UserService {
       if (Boolean.TRUE.equals(request.getLocked())) {
         refreshTokenService.deleteRefreshToken(userId);
       }
-    } catch (Exception e) {
+    } catch (org.springframework.data.redis.RedisConnectionFailureException
+        | org.springframework.data.redis.RedisSystemException e) {
       log.error(
           "Redis 업데이트 실패 (DB는 정상 처리됨, 다음 인증 시 자동 복구): userId={}, locked={}",
           userId,

--- a/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
@@ -35,7 +35,7 @@ public class UserService {
   private final PasswordEncoder passwordEncoder;
   private final ProfileImageUploadService profileImageUploadService;
   private final RefreshTokenService refreshTokenService;
-  private final RedisTemplate<String, Boolean> redisTemplate;
+  private final RedisTemplate<String, String> redisTemplate;
   private final JwtTokenProvider jwtTokenProvider;
 
   /** 회원가입 */
@@ -157,14 +157,13 @@ public class UserService {
           .opsForValue()
           .set(
               redisKey,
-              request.getLocked(),
+              String.valueOf(request.getLocked()),
               Duration.ofSeconds(jwtTokenProvider.getAccessTokenValidityInSeconds()));
 
       if (Boolean.TRUE.equals(request.getLocked())) {
         refreshTokenService.deleteRefreshToken(userId);
       }
-    } catch (org.springframework.data.redis.RedisConnectionFailureException
-        | org.springframework.data.redis.RedisSystemException e) {
+    } catch (Exception e) {
       log.error(
           "Redis 업데이트 실패 (DB는 정상 처리됨, 다음 인증 시 자동 복구): userId={}, locked={}",
           userId,

--- a/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
@@ -176,7 +176,7 @@ public class UserService {
           return false;
         }
         try {
-          Thread.sleep(100 * attempt);
+          Thread.sleep(100L * attempt);
         } catch (InterruptedException ie) {
           Thread.currentThread().interrupt();
           log.error("Redis Key 삭제 재시도 중단됨: key = {}", redisKey);

--- a/mopl-infrastructure/redis/src/main/java/io/mopl/redis/config/RedisConfig.java
+++ b/mopl-infrastructure/redis/src/main/java/io/mopl/redis/config/RedisConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericToStringSerializer;
 import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -42,6 +43,17 @@ public class RedisConfig {
     template.setHashValueSerializer(RedisSerializer.json());
 
     template.afterPropertiesSet();
+    return template;
+  }
+
+  /** Boolean 전용 RedisTemplate Bean */
+  @Bean
+  public RedisTemplate<String, Boolean> redisTemplateForBoolean(
+      RedisConnectionFactory connectionFactory) {
+    RedisTemplate<String, Boolean> template = new RedisTemplate<>();
+    template.setConnectionFactory(connectionFactory);
+    template.setKeySerializer(new StringRedisSerializer());
+    template.setValueSerializer(new GenericToStringSerializer<>(Boolean.class));
     return template;
   }
 }

--- a/mopl-infrastructure/redis/src/main/java/io/mopl/redis/config/RedisConfig.java
+++ b/mopl-infrastructure/redis/src/main/java/io/mopl/redis/config/RedisConfig.java
@@ -52,8 +52,11 @@ public class RedisConfig {
       RedisConnectionFactory connectionFactory) {
     RedisTemplate<String, Boolean> template = new RedisTemplate<>();
     template.setConnectionFactory(connectionFactory);
+
     template.setKeySerializer(new StringRedisSerializer());
     template.setValueSerializer(new GenericToStringSerializer<>(Boolean.class));
+
+    template.afterPropertiesSet();
     return template;
   }
 }

--- a/mopl-infrastructure/redis/src/main/java/io/mopl/redis/constants/RedisKeyPrefix.java
+++ b/mopl-infrastructure/redis/src/main/java/io/mopl/redis/constants/RedisKeyPrefix.java
@@ -4,11 +4,11 @@ public final class RedisKeyPrefix {
 
   // ===== 인증 =====
 
-  /** 리프레시 토큰 : rt:{userId} */
+  /** 리프레시 토큰: rt:{userId} */
   public static final String REFRESH_TOKEN = "rt:";
 
-  /** 이메일 인증 코드: email:verify:{email} */
-  public static final String EMAIL_VERIFICATION = "email:verify:";
+  /** 사용자 잠금 상태: user:locked:{userId} */
+  public static final String USER_LOCKED = "user:locked:";
 
   /** 인스턴스화 방지 */
   private RedisKeyPrefix() {


### PR DESCRIPTION
## 📌 작업 개요
- 작업 내용: 사용자 계정 잠금 API 구현
- 관련 이슈: 

## 🚀 주요 변경 사항
- [x] 사용자 계정 잠금 API 구현
- [ ] (변경 사항 2)

## 🛠 DB 변경 사항
- [ ] MySQL 스키마 변경 여부 (DDL 첨부)
- [ ] Redis 키 구조 변경 여부

## 🧪 테스트 결과 (필수)
> 팀 가이드에 따라 Postman/local 환경에서의 기능 테스트를 완료해야 합니다.

- [x] **테스트 수행 완료**
- **테스트 시나리오:**
1. 어드민, 유저 계정으로 각각 접속
2. 어드민이 사용자 계정 잠금 처리
3. 계정 잠금 성공 확인
4. 사용자 계정 강제 로그아웃 확인
5. 잠금 유저의 로그인 시도 및 로그인 실패 확인
6. 해당 유저의 계정 잠금 해제
7. 잠금 해제된 유저의 로그인 시도 및 로그인 성공 확인
- **증빙자료:** (Postman 응답 결과 캡쳐본 첨부 또는 JSON 응답 복사)
<img width="1927" height="901" alt="01  어드민, 유저 계정으로 각각 접속" src="https://github.com/user-attachments/assets/d27dfa07-356e-4fdf-aff5-137a4bef7593" />
<img width="1927" height="901" alt="02  사용자 계정 잠금 처리" src="https://github.com/user-attachments/assets/cf525cf0-bdb4-436a-8eb1-42c9ea82fd9e" />
<img width="1927" height="901" alt="03  계정 잠금 성공" src="https://github.com/user-attachments/assets/b21c2dc6-b502-404e-bdef-1405a39e4fa0" />
<img width="1927" height="901" alt="04  사용자 계정 강제 로그아웃" src="https://github.com/user-attachments/assets/ade79e19-0169-47d7-bb77-86d7900cdd36" />
<img width="1927" height="901" alt="05  잠금 유저 로그인 시도" src="https://github.com/user-attachments/assets/88fcbbe3-74fe-4be0-9fcb-fc93d8a2611c" />
<img width="1927" height="901" alt="06  잠금 유저 로그인 실패" src="https://github.com/user-attachments/assets/e30efe8a-b2ba-4c89-9722-ff06b7718ed3" />
<img width="1927" height="901" alt="07  유저 계정 잠금 해제" src="https://github.com/user-attachments/assets/72444e7d-2e98-4398-ae31-105886ae4372" />
<img width="1927" height="901" alt="08  유저 계정 잠금 해제 성공" src="https://github.com/user-attachments/assets/cdbc1b5f-b247-4569-9a32-b0052a285998" />
<img width="1927" height="901" alt="09  잠금 해제 유저 로그인 성공" src="https://github.com/user-attachments/assets/cbaad11e-bf49-4d4e-be65-4d808e8b5118" />

## ✅ 체크리스트
- [x] 코드 컨벤션(Checkstyle/Spotless)을 준수했는가?
- [x] 빌드가 성공적으로 수행되는가? (`./gradlew build`)
- [x] 불필요한 주석이나 print문은 제거했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 관리자가 사용자 계정을 잠금/해제할 수 있는 API 추가
  * 사용자가 프로필 정보와 프로필 이미지를 업데이트할 수 있는 기능 추가

* **개선사항**
  * 계정 잠금 상태 조회에 캐시 도입으로 인증 성능 향상
  * 계정 잠금 시 기존 인증(토큰) 무효화로 보안 강화
  * 인증 실패 시 다국어(지역화) 오류 메시지 제공

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->