### PR TITLE
refactor: 컨텐츠 삭제 시, s3에서 썸네일 삭제

### DIFF
--- a/mopl-api/src/main/java/io/mopl/api/content/service/ContentService.java
+++ b/mopl-api/src/main/java/io/mopl/api/content/service/ContentService.java
@@ -127,12 +127,14 @@ public class ContentService {
   @PreAuthorize("hasRole('ADMIN')")
   public void delete(UUID contentId) {
     log.info("컨텐츠 삭제 시작: contentId: {}", contentId);
-    contentRepository
-        .findById(contentId)
-        .orElseThrow(() -> new BusinessException(ContentErrorCode.CONTENT_NOT_FOUND));
+    Content content =
+        contentRepository
+            .findById(contentId)
+            .orElseThrow(() -> new BusinessException(ContentErrorCode.CONTENT_NOT_FOUND));
     reviewRepository.deleteByContentId(contentId);
     playlistContentRepository.deleteByIdContentId(contentId);
     contentTagRepository.deleteByIdContentId(contentId);
+    contentThumbnailUploadService.deleteThumbnail(content.getThumbnailUrl());
     contentRepository.deleteById(contentId);
     log.info("컨텐츠 삭제 완료: contentId: {}", contentId);
   }

--- a/mopl-api/src/main/java/io/mopl/api/content/service/ContentThumbnailUploadService.java
+++ b/mopl-api/src/main/java/io/mopl/api/content/service/ContentThumbnailUploadService.java
@@ -131,4 +131,24 @@ public class ContentThumbnailUploadService {
       return null;
     }
   }
+
+  public void deleteThumbnail(String key) {
+    if (key == null || key.isBlank()) {
+      return;
+    }
+
+    // URL이 넘어오면 삭제 불가(키가 필요)
+    if (key.startsWith("https://") || key.startsWith("http://")) {
+      log.warn("Thumbnail key is URL, skip delete. key={}", key);
+      return;
+    }
+
+    try {
+      s3Client.deleteObject(builder -> builder.bucket(s3Properties.getBucket()).key(key));
+      log.info("썸네일 삭제 성공 - key = {}", key);
+    } catch (SdkException e) {
+      log.error("썸네일 삭제 실패 - key = {}", key, e);
+      throw new BusinessException(CommonErrorCode.INTERNAL_SERVER_ERROR);
+    }
+  }
 }


### PR DESCRIPTION
## 📌 작업 개요
- 작업 내용: 컨텐츠 삭제 시, s3에서 썸네일 삭제
- 관련 이슈: 

## 🚀 주요 변경 사항
- 컨텐츠 삭제 시, Content 삭제 전, 썸네일을 s3에서 삭제하도록 함

## 🛠 DB 변경 사항
- [ ] MySQL 스키마 변경 여부 (DDL 첨부)
- [ ] Redis 키 구조 변경 여부

## 🧪 테스트 결과 (필수)
> 팀 가이드에 따라 Postman/local 환경에서의 기능 테스트를 완료해야 합니다.

- [x] **테스트 수행 완료**

### 로컬 테스트
- 삭제 전
<img width="1267" height="387" alt="image" src="https://github.com/user-attachments/assets/de89bda4-e490-4bf4-9c27-d163fe0bf06a" />
<img width="1523" height="596" alt="image" src="https://github.com/user-attachments/assets/16b4e5cc-dff8-4390-8a9b-78e2758f3365" />

- 삭제 후
<img width="473" height="103" alt="image" src="https://github.com/user-attachments/assets/fdf1eb54-f209-4c5f-83cd-039dca64b9ef" />
<img width="1466" height="793" alt="image" src="https://github.com/user-attachments/assets/e52c919e-3e5a-4be5-8136-3e80863cb6aa" />

<br><br>

### Postman 테스트
- 삭제 전
<img width="1332" height="683" alt="image" src="https://github.com/user-attachments/assets/038ca9fc-f463-4c3f-bd96-a235fb35e3f6" />
- 삭제 후
<img width="1390" height="699" alt="image" src="https://github.com/user-attachments/assets/0b96b251-2a88-40e2-b8ea-0d8c5b197316" />
<img width="1431" height="678" alt="image" src="https://github.com/user-attachments/assets/c7349b86-e817-40d1-b1fd-d71394f2d162" />


- **테스트 시나리오:** (예: 이메일 중복 체크 -> 회원가입 성공 -> 로그인 확인)
- **증빙자료:** (Postman 응답 결과 캡쳐본 첨부 또는 JSON 응답 복사)

## ✅ 체크리스트
- [x] 코드 컨벤션(Checkstyle/Spotless)을 준수했는가?
- [x] 빌드가 성공적으로 수행되는가? (`./gradlew build`)
- [ ] 불필요한 주석이나 print문은 제거했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 콘텐츠 삭제 시 관련 썸네일이 올바르게 정리되도록 개선했습니다.
  * 콘텐츠 삭제 프로세스에서 S3 저장소의 이미지 파일 정리 기능을 추가했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->