### PR TITLE
feat: SecurityConfig에서 "/api/auth/refresh"를 csrf 필터에서 제외

### DIFF
--- a/mopl-api/src/main/java/io/mopl/api/common/config/SecurityConfig.java
+++ b/mopl-api/src/main/java/io/mopl/api/common/config/SecurityConfig.java
@@ -68,6 +68,8 @@ public class SecurityConfig {
                           return (method.equals("POST") && path.equals("/api/auth/sign-in"))
                               || (method.equals("POST") && path.equals("/api/users"))
                               || (method.equals("POST") && path.equals("/api/auth/reset-password"))
+                              || (method.equals("POST") && path.equals("/api/auth/refresh"))
+                              || path.startsWith("/oauth2/")
                               || path.startsWith("/login/oauth2/");
                         }))
         .sessionManagement(
@@ -107,8 +109,6 @@ public class SecurityConfig {
 
                     /* ========== 인증 관리 ========== */
                     // 전체: 모든 기능
-                    .requestMatchers(HttpMethod.GET, "/api/auth/refresh")
-                    .permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/auth/sign-in", "/api/auth/refresh")
                     .permitAll()
                     .requestMatchers("/api/auth/**")


### PR DESCRIPTION
## 📌 작업 개요
- 작업 내용: SecurityConfig에서 "/api/auth/refresh"를 csrf 필터에서 제외
- 관련 이슈: #이슈번호

## 🚀 주요 변경 사항
- [x] feat: SecurityConfig에서 "/api/auth/refresh"를 csrf 필터에서 제외
- [ ] (변경 사항 2)

## 🛠 DB 변경 사항
- [ ] MySQL 스키마 변경 여부 (DDL 첨부)
- [ ] Redis 키 구조 변경 여부

## 🧪 테스트 결과 (필수)
> 팀 가이드에 따라 Postman/local 환경에서의 기능 테스트를 완료해야 합니다.

- [x] **테스트 수행 완료**
- **테스트 시나리오:** (예: 이메일 중복 체크 -> 회원가입 성공 -> 로그인 확인)
- **증빙자료:** (Postman 응답 결과 캡쳐본 첨부 또는 JSON 응답 복사)

## ✅ 체크리스트
- [x] 코드 컨벤션(Checkstyle/Spotless)을 준수했는가?
- [x] 빌드가 성공적으로 수행되는가? (`./gradlew build`)
- [x] 불필요한 주석이나 print문은 제거했는가?

## 추가 설명
본래 csrf 필터에 최대한 refresh 를 제외하지 않으려고 했는데, 프론트엔드 동작 상
구글로 시작하기 혹은 카카오로 시작하기 UI 클릭 시 refresh를 호출합니다.
이 경우 아직 로그인이 되어 있지 않은 상황이므로 refresh 토큰이 없는데 refresh를 호출해서 인증되지 않은 사용자라고 판단, sign-in 화면으로 돌려보내는 과정이 계속 수행되어서...불가피하게 refresh를 csrf 필터에서 제외했습니다.
해결 방법을 찾게 되면 다시 수정해보겠습니다ㅠ 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **보안**
  * OAuth2 인증 경로 처리 개선
  * 인증 토큰 갱신 엔드포인트의 보안 설정 업데이트

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->