### PR TITLE
feat: 유저권한 변경 알림 이벤트 발행 구현

### DIFF
--- a/mopl-api/src/main/java/io/mopl/api/user/event/UserRoleChangedInternalEvent.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/event/UserRoleChangedInternalEvent.java
@@ -1,0 +1,5 @@
+package io.mopl.api.user.event;
+
+import java.util.UUID;
+
+public record UserRoleChangedInternalEvent(UUID userId, String userName, String newRole) {}

--- a/mopl-api/src/main/java/io/mopl/api/user/event/UserRoleEventPublisher.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/event/UserRoleEventPublisher.java
@@ -1,0 +1,18 @@
+package io.mopl.api.user.event;
+
+import io.mopl.core.event.user.UserRoleChangedEvent;
+import io.mopl.core.kafka.KafkaTopics;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserRoleEventPublisher {
+
+  private final KafkaTemplate<String, Object> kafkaTemplate;
+
+  public void publish(UserRoleChangedEvent event) {
+    kafkaTemplate.send(KafkaTopics.USER_ROLE_CHANGED, event.userId(), event);
+  }
+}

--- a/mopl-api/src/main/java/io/mopl/api/user/event/UserRoleKafkaEventListener.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/event/UserRoleKafkaEventListener.java
@@ -4,10 +4,12 @@ import io.mopl.core.event.user.UserRoleChangedEvent;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class UserRoleKafkaEventListener {
@@ -24,6 +26,10 @@ public class UserRoleKafkaEventListener {
             event.userName(),
             event.newRole());
 
-    publisher.publish(kafkaEvent);
+    try {
+      publisher.publish(kafkaEvent);
+    } catch (Exception e) {
+      log.error("권한 변경 이벤트 Kafka 발행 실패 - userId: {}", event.userId(), e);
+    }
   }
 }

--- a/mopl-api/src/main/java/io/mopl/api/user/event/UserRoleKafkaEventListener.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/event/UserRoleKafkaEventListener.java
@@ -1,0 +1,29 @@
+package io.mopl.api.user.event;
+
+import io.mopl.core.event.user.UserRoleChangedEvent;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class UserRoleKafkaEventListener {
+
+  private final UserRoleEventPublisher publisher;
+
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void onRoleChanged(UserRoleChangedInternalEvent event) {
+    UserRoleChangedEvent kafkaEvent =
+        new UserRoleChangedEvent(
+            UUID.randomUUID().toString(),
+            Instant.now(),
+            event.userId().toString(),
+            event.userName(),
+            event.newRole());
+
+    publisher.publish(kafkaEvent);
+  }
+}

--- a/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
@@ -13,6 +13,7 @@ import io.mopl.api.user.dto.UserLockUpdateRequest;
 import io.mopl.api.user.dto.UserRoleUpdateRequest;
 import io.mopl.api.user.dto.UserSummary;
 import io.mopl.api.user.dto.UserUpdateRequest;
+import io.mopl.api.user.event.UserRoleChangedInternalEvent;
 import io.mopl.core.error.BusinessException;
 import io.mopl.core.error.CommonErrorCode;
 import io.mopl.redis.constants.RedisKeyPrefix;
@@ -20,6 +21,7 @@ import java.time.Duration;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -37,6 +39,7 @@ public class UserService {
   private final ProfileImageUploadService profileImageUploadService;
   private final RedisTemplate<String, String> redisTemplate;
   private final RefreshTokenService refreshTokenService;
+  private final ApplicationEventPublisher eventPublisher;
 
   /** 회원가입 */
   @Transactional
@@ -218,5 +221,8 @@ public class UserService {
       log.error("계정 권한 변경 뒤 Refresh Token 삭제 실패 - userId: {}", userId, e);
       throw new BusinessException(CommonErrorCode.INTERNAL_SERVER_ERROR);
     }
+
+    eventPublisher.publishEvent(
+        new UserRoleChangedInternalEvent(userId, user.getName(), user.getRole().name()));
   }
 }

--- a/mopl-core/src/main/java/io/mopl/core/db/DbConstraintNames.java
+++ b/mopl-core/src/main/java/io/mopl/core/db/DbConstraintNames.java
@@ -1,0 +1,9 @@
+package io.mopl.core.db;
+
+public final class DbConstraintNames {
+
+  public static final String UQ_NOTIFICATIONS_EVENT_ID = "uq_notifications_event_id";
+  public static final String FK_NOTIFICATIONS_RECEIVER = "fk_notifications_receiver";
+
+  private DbConstraintNames() {}
+}

--- a/mopl-core/src/main/java/io/mopl/core/event/user/UserRoleChangedEvent.java
+++ b/mopl-core/src/main/java/io/mopl/core/event/user/UserRoleChangedEvent.java
@@ -1,0 +1,6 @@
+package io.mopl.core.event.user;
+
+import java.time.Instant;
+
+public record UserRoleChangedEvent(
+    String eventId, Instant occurredAt, String userId, String userName, String newRole) {}

--- a/mopl-worker/src/main/java/io/mopl/worker/notification/FollowNotificationListener.java
+++ b/mopl-worker/src/main/java/io/mopl/worker/notification/FollowNotificationListener.java
@@ -1,5 +1,6 @@
 package io.mopl.worker.notification;
 
+import io.mopl.core.db.DbConstraintNames;
 import io.mopl.core.event.follow.UserFollowedEvent;
 import io.mopl.core.kafka.KafkaTopics;
 import io.mopl.worker.notification.domain.Notification;
@@ -36,7 +37,10 @@ public class FollowNotificationListener {
 
       String title =
           messageSource.getMessage(
-              "notification.follow.title", new Object[] {event.followerName()}, Locale.KOREAN);
+              "notification.follow.title",
+              new Object[] {event.followerName()},
+              "새 팔로워: " + event.followerName(),
+              Locale.KOREAN);
 
       Notification notification =
           Notification.builder()
@@ -52,10 +56,10 @@ public class FollowNotificationListener {
       Throwable cause = e.getMostSpecificCause();
       String message = cause != null ? cause.getMessage() : e.getMessage();
 
-      if (message != null && message.contains("uq_notifications_event_id")) {
+      if (message != null && message.contains(DbConstraintNames.UQ_NOTIFICATIONS_EVENT_ID)) {
         // 이미 처리된 이벤트는 무시한다.
         log.debug("중복 이벤트 무시 (eventId={})", event.eventId());
-      } else if (message != null && message.contains("fk_notifications_receiver")) {
+      } else if (message != null && message.contains(DbConstraintNames.FK_NOTIFICATIONS_RECEIVER)) {
         log.error("수신자 참조 오류 (eventId={})", event.eventId(), e);
       } else {
         log.error("알림 저장 중 오류 (eventId={})", event.eventId(), e);

--- a/mopl-worker/src/main/java/io/mopl/worker/notification/PlaylistNotificationListener.java
+++ b/mopl-worker/src/main/java/io/mopl/worker/notification/PlaylistNotificationListener.java
@@ -1,5 +1,6 @@
 package io.mopl.worker.notification;
 
+import io.mopl.core.db.DbConstraintNames;
 import io.mopl.core.event.playlist.PlaylistContentAddedEvent;
 import io.mopl.core.event.playlist.PlaylistCreatedEvent;
 import io.mopl.core.event.playlist.PlaylistSubscribedEvent;
@@ -43,6 +44,7 @@ public class PlaylistNotificationListener {
           messageSource.getMessage(
               "notification.playlist.subscribed.title",
               new Object[] {event.subscriberName()},
+              "새 구독자: " + event.subscriberName(),
               Locale.KOREAN);
 
       Notification notification =
@@ -75,7 +77,10 @@ public class PlaylistNotificationListener {
 
       String title =
           messageSource.getMessage(
-              "notification.playlist.content-added.title", null, Locale.KOREAN);
+              "notification.playlist.content-added.title",
+              null,
+              "플레이리스트에 새 콘텐츠가 추가되었습니다.",
+              Locale.KOREAN);
 
       List<UUID> receiverIds = recipientQuery.findSubscriberIds(playlistIdUuid);
       for (UUID receiverId : receiverIds) {
@@ -116,6 +121,7 @@ public class PlaylistNotificationListener {
           messageSource.getMessage(
               "notification.playlist.created.title",
               new Object[] {event.ownerName()},
+              "새 플레이리스트가 생성되었습니다. 작성자: " + event.ownerName(),
               Locale.KOREAN);
 
       List<UUID> receiverIds = recipientQuery.findFollowerIds(ownerIdUuid);
@@ -148,9 +154,9 @@ public class PlaylistNotificationListener {
     Throwable cause = e.getMostSpecificCause();
     String message = cause != null ? cause.getMessage() : e.getMessage();
 
-    if (message != null && message.contains("uq_notifications_event_id")) {
+    if (message != null && message.contains(DbConstraintNames.UQ_NOTIFICATIONS_EVENT_ID)) {
       log.debug("중복 이벤트 무시 (eventId={})", eventId);
-    } else if (message != null && message.contains("fk_notifications_receiver")) {
+    } else if (message != null && message.contains(DbConstraintNames.FK_NOTIFICATIONS_RECEIVER)) {
       log.error("수신자 참조 오류 (eventId={})", eventId, e);
     } else {
       log.error("알림 저장 중 오류 (eventId={})", eventId, e);

--- a/mopl-worker/src/main/java/io/mopl/worker/notification/UserRoleNotificationListener.java
+++ b/mopl-worker/src/main/java/io/mopl/worker/notification/UserRoleNotificationListener.java
@@ -1,5 +1,6 @@
 package io.mopl.worker.notification;
 
+import io.mopl.core.db.DbConstraintNames;
 import io.mopl.core.event.user.UserRoleChangedEvent;
 import io.mopl.core.kafka.KafkaTopics;
 import io.mopl.worker.notification.domain.Notification;
@@ -38,6 +39,7 @@ public class UserRoleNotificationListener {
           messageSource.getMessage(
               "notification.user.role-changed.title",
               new Object[] {event.newRole()},
+              "권한이 " + event.newRole() + "(으)로 변경되었습니다.",
               Locale.KOREAN);
 
       Notification notification =
@@ -68,9 +70,9 @@ public class UserRoleNotificationListener {
     Throwable cause = e.getMostSpecificCause();
     String message = cause != null ? cause.getMessage() : e.getMessage();
 
-    if (message != null && message.contains("uq_notifications_event_id")) {
+    if (message != null && message.contains(DbConstraintNames.UQ_NOTIFICATIONS_EVENT_ID)) {
       log.debug("이미 처리된 이벤트입니다. 중복 저장을 건너뜁니다. (eventId={})", eventId);
-    } else if (message != null && message.contains("fk_notifications_receiver")) {
+    } else if (message != null && message.contains(DbConstraintNames.FK_NOTIFICATIONS_RECEIVER)) {
       log.error("수신자 참조 무결성 오류가 발생했습니다. (eventId={})", eventId, e);
     } else {
       log.error("알림 저장 중 오류가 발생했습니다. (eventId={})", eventId, e);

--- a/mopl-worker/src/main/java/io/mopl/worker/notification/UserRoleNotificationListener.java
+++ b/mopl-worker/src/main/java/io/mopl/worker/notification/UserRoleNotificationListener.java
@@ -1,0 +1,82 @@
+package io.mopl.worker.notification;
+
+import io.mopl.core.event.user.UserRoleChangedEvent;
+import io.mopl.core.kafka.KafkaTopics;
+import io.mopl.worker.notification.domain.Notification;
+import io.mopl.worker.notification.domain.NotificationLevel;
+import io.mopl.worker.notification.domain.NotificationRepository;
+import java.util.Locale;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.MessageSource;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserRoleNotificationListener {
+
+  private final NotificationRepository notificationRepository;
+  private final MessageSource messageSource;
+  private final NotificationEventPublisher notificationEventPublisher;
+
+  // 권한 변경 이벤트를 소비해 알림을 저장한다.
+  @KafkaListener(
+      topics = KafkaTopics.USER_ROLE_CHANGED,
+      properties = "spring.json.value.default.type=io.mopl.core.event.user.UserRoleChangedEvent")
+  public void handle(UserRoleChangedEvent event, Acknowledgment acknowledgment) {
+    try {
+      UUID eventIdUuid = parseUuid(event.eventId(), "eventId", event.eventId());
+      UUID userIdUuid = parseUuid(event.userId(), "userId", event.eventId());
+
+      String title =
+          messageSource.getMessage(
+              "notification.user.role-changed.title",
+              new Object[] {event.newRole()},
+              Locale.KOREAN);
+
+      Notification notification =
+          Notification.builder()
+              .eventId(eventIdUuid)
+              .receiverId(userIdUuid)
+              .title(title)
+              .content("")
+              .level(NotificationLevel.INFO)
+              .build();
+      Notification saved = notificationRepository.save(notification);
+      notificationEventPublisher.publish(saved);
+    } catch (DataIntegrityViolationException e) {
+      handleDataIntegrityViolation(e, event.eventId());
+    } catch (IllegalArgumentException e) {
+      // UUID 파싱 오류는 parseUuid에서 로깅한다.
+    } finally {
+      acknowledgment.acknowledge();
+    }
+  }
+
+  private void handleDataIntegrityViolation(DataIntegrityViolationException e, String eventId) {
+    Throwable cause = e.getMostSpecificCause();
+    String message = cause != null ? cause.getMessage() : e.getMessage();
+
+    if (message != null && message.contains("uq_notifications_event_id")) {
+      log.debug("중복 이벤트 무시 (eventId={})", eventId);
+    } else if (message != null && message.contains("fk_notifications_receiver")) {
+      log.error("수신자 참조 오류 (eventId={})", eventId, e);
+    } else {
+      log.error("알림 저장 중 오류 (eventId={})", eventId, e);
+    }
+  }
+
+  private UUID parseUuid(String value, String fieldName, String eventId) {
+    try {
+      return UUID.fromString(value);
+    } catch (IllegalArgumentException e) {
+      log.error("UUID 형식이 올바르지 않습니다: {} (eventId={})", fieldName, eventId, e);
+      throw e;
+    }
+  }
+}

--- a/mopl-worker/src/main/java/io/mopl/worker/notification/UserRoleNotificationListener.java
+++ b/mopl-worker/src/main/java/io/mopl/worker/notification/UserRoleNotificationListener.java
@@ -24,11 +24,12 @@ public class UserRoleNotificationListener {
   private final MessageSource messageSource;
   private final NotificationEventPublisher notificationEventPublisher;
 
-  // 권한 변경 이벤트를 소비해 알림을 저장한다.
+  // 사용자 권한 변경 이벤트를 수신해 알림을 생성한다.
   @KafkaListener(
       topics = KafkaTopics.USER_ROLE_CHANGED,
       properties = "spring.json.value.default.type=io.mopl.core.event.user.UserRoleChangedEvent")
   public void handle(UserRoleChangedEvent event, Acknowledgment acknowledgment) {
+    boolean shouldAck = false;
     try {
       UUID eventIdUuid = parseUuid(event.eventId(), "eventId", event.eventId());
       UUID userIdUuid = parseUuid(event.userId(), "userId", event.eventId());
@@ -49,12 +50,17 @@ public class UserRoleNotificationListener {
               .build();
       Notification saved = notificationRepository.save(notification);
       notificationEventPublisher.publish(saved);
+      shouldAck = true;
     } catch (DataIntegrityViolationException e) {
       handleDataIntegrityViolation(e, event.eventId());
+      shouldAck = true;
     } catch (IllegalArgumentException e) {
-      // UUID 파싱 오류는 parseUuid에서 로깅한다.
+      shouldAck = true;
+      // UUID 형식 오류로 parseUuid가 실패한 경우.
     } finally {
-      acknowledgment.acknowledge();
+      if (shouldAck) {
+        acknowledgment.acknowledge();
+      }
     }
   }
 
@@ -63,11 +69,11 @@ public class UserRoleNotificationListener {
     String message = cause != null ? cause.getMessage() : e.getMessage();
 
     if (message != null && message.contains("uq_notifications_event_id")) {
-      log.debug("중복 이벤트 무시 (eventId={})", eventId);
+      log.debug("이미 처리된 이벤트입니다. 중복 저장을 건너뜁니다. (eventId={})", eventId);
     } else if (message != null && message.contains("fk_notifications_receiver")) {
-      log.error("수신자 참조 오류 (eventId={})", eventId, e);
+      log.error("수신자 참조 무결성 오류가 발생했습니다. (eventId={})", eventId, e);
     } else {
-      log.error("알림 저장 중 오류 (eventId={})", eventId, e);
+      log.error("알림 저장 중 오류가 발생했습니다. (eventId={})", eventId, e);
     }
   }
 
@@ -75,7 +81,7 @@ public class UserRoleNotificationListener {
     try {
       return UUID.fromString(value);
     } catch (IllegalArgumentException e) {
-      log.error("UUID 형식이 올바르지 않습니다: {} (eventId={})", fieldName, eventId, e);
+      log.error("UUID 형식이 올바르지 않습니다. 필드: {} (eventId={})", fieldName, eventId, e);
       throw e;
     }
   }

--- a/mopl-worker/src/main/resources/application-dev.yml
+++ b/mopl-worker/src/main/resources/application-dev.yml
@@ -3,7 +3,7 @@ spring:
     activate:
       on-profile: dev
   datasource:
-    url: ${MOPL_DB_URL:jdbc:mysql://localhost:3306/mopl?useSSL=false&serverTimezone=UTC&characterEncoding=UTF-8}
+    url: ${MOPL_DB_URL:jdbc:mysql://localhost:3306/mopl?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC&characterEncoding=UTF-8}
     username: ${MOPL_DB_USERNAME:app}
     password: ${MOPL_DB_PASSWORD:app}
   jpa:


### PR DESCRIPTION
## 📌 작업 개요
- 작업 내용: 유저 권한 변경 알림 이벤트 발행 구현
- 관련 이슈: 없음

## 🚀 주요 변경 사항
- 관리자가 유저권한 변경 시 알림 이벤트 발행 기능 구현 

## 🛠 DB 변경 사항
- 없음

## 🧪 테스트 결과 (필수)
<img width="2335" height="790" alt="유저 권한 토픽 확인 " src="https://github.com/user-attachments/assets/899c4dac-e552-42ba-a5b5-9551041a6af5" />
<img width="1686" height="29" alt="권한 변경 확인" src="https://github.com/user-attachments/assets/d22f4928-7f4f-4768-8343-d2326e818f65" />

- [x] **테스트 수행 완료**
- **테스트 시나리오:** 제 파트가 아니여서 Postman 테스트를 하지 않고 local 테스트를 진행하였습니다.

## ✅ 체크리스트
- [x] 코드 컨벤션(Checkstyle/Spotless)을 준수했는가?
- [x] 빌드가 성공적으로 수행되는가? (`./gradlew build`)
- [x] 불필요한 주석이나 print문은 제거했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 역할 변경 시 내부 이벤트 발행 및 Kafka 이벤트 전파 기능 추가.
  * 역할 변경 Kafka 수신기 추가로 이벤트를 받아 알림 생성·발행.
  * 역할 변경 이벤트 소비자(워커) 추가: 로컬라이즈된 알림 저장 및 발행 처리.

* **기타**
  * 알림 관련 DB 제약명 상수화 및 기존 리스너의 제약 검사/기본 메시지 개선.
  * 개발 환경 데이터베이스 연결 설정 업데이트.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->