### PR TITLE
각 토큰 별 경로 재설정

### DIFF
--- a/mopl-api/src/main/java/io/mopl/api/auth/controller/AuthController.java
+++ b/mopl-api/src/main/java/io/mopl/api/auth/controller/AuthController.java
@@ -70,7 +70,7 @@ public class AuthController {
     Cookie cookie = new Cookie(cookieSecurityProperties.getRefreshToken().getName(), null);
     cookie.setHttpOnly(true);
     cookie.setSecure(cookieSecurityProperties.isSecure());
-    cookie.setPath("/");
+    cookie.setPath("/api/auth");
     cookie.setMaxAge(0);
     cookie.setAttribute("SameSite", cookieSecurityProperties.getSameSite());
 
@@ -105,7 +105,7 @@ public class AuthController {
     Cookie cookie = new Cookie(cookieSecurityProperties.getRefreshToken().getName(), refreshToken);
     cookie.setHttpOnly(true);
     cookie.setSecure(cookieSecurityProperties.isSecure());
-    cookie.setPath("/");
+    cookie.setPath("/api/auth");
     cookie.setMaxAge((int) jwtTokenProvider.getRefreshTokenValidityInSeconds());
     cookie.setAttribute("SameSite", cookieSecurityProperties.getSameSite());
 

--- a/mopl-api/src/main/java/io/mopl/api/auth/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/mopl-api/src/main/java/io/mopl/api/auth/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -61,7 +61,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
     Cookie cookie = new Cookie(cookieSecurityProperties.getRefreshToken().getName(), refreshToken);
     cookie.setHttpOnly(true);
     cookie.setSecure(cookieSecurityProperties.isSecure());
-    cookie.setPath("/");
+    cookie.setPath("/api/auth");
     cookie.setMaxAge((int) jwtTokenProvider.getRefreshTokenValidityInSeconds());
     cookie.setAttribute("SameSite", cookieSecurityProperties.getSameSite());
 

--- a/mopl-api/src/main/java/io/mopl/api/common/config/SecurityConfig.java
+++ b/mopl-api/src/main/java/io/mopl/api/common/config/SecurityConfig.java
@@ -15,7 +15,6 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
-import org.springframework.security.web.csrf.CsrfFilter;
 import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -27,7 +26,6 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SecurityConfig {
 
   private final JwtAuthenticationFilter jwtAuthenticationFilter;
-  private final CsrfCookieFilter csrfCookieFilter;
 
   private final CustomOAuth2UserService customOAuth2UserService;
   private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
@@ -68,6 +66,8 @@ public class SecurityConfig {
                           return (method.equals("POST") && path.equals("/api/auth/sign-in"))
                               || (method.equals("POST") && path.equals("/api/users"))
                               || (method.equals("POST") && path.equals("/api/auth/reset-password"))
+                              //                              || (method.equals("POST") &&
+                              // path.equals("/api/auth/refresh"))
                               || path.startsWith("/login/oauth2/");
                         }))
         .sessionManagement(
@@ -228,8 +228,7 @@ public class SecurityConfig {
                     .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
                     .successHandler(oAuth2AuthenticationSuccessHandler)
                     .failureHandler(oAuth2AuthenticationFailureHandler))
-        .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-        .addFilterAfter(csrfCookieFilter, CsrfFilter.class);
+        .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
     return http.build();
   }

--- a/mopl-api/src/main/java/io/mopl/api/common/config/SecurityConfig.java
+++ b/mopl-api/src/main/java/io/mopl/api/common/config/SecurityConfig.java
@@ -66,8 +66,6 @@ public class SecurityConfig {
                           return (method.equals("POST") && path.equals("/api/auth/sign-in"))
                               || (method.equals("POST") && path.equals("/api/users"))
                               || (method.equals("POST") && path.equals("/api/auth/reset-password"))
-                              //                              || (method.equals("POST") &&
-                              // path.equals("/api/auth/refresh"))
                               || path.startsWith("/login/oauth2/");
                         }))
         .sessionManagement(


### PR DESCRIPTION
## 📌 작업 개요
- 작업 내용: 각 토큰 별 경로 재설정
- 관련 이슈: #이슈번호

## 🚀 주요 변경 사항
- [x] refresh token의 경로는 "/api/auth", access token의 경로는 "/" 로 재설정했습니다.
- [ ] (변경 사항 2)

## 🛠 DB 변경 사항
- [ ] MySQL 스키마 변경 여부 (DDL 첨부)
- [ ] Redis 키 구조 변경 여부

## 🧪 테스트 결과 (필수)
> 팀 가이드에 따라 Postman/local 환경에서의 기능 테스트를 완료해야 합니다.

- [x] **테스트 수행 완료**
- **테스트 시나리오:** 
캐시 비우기 및 강력 새로고침 이후 각 토큰 정확히 생성되는 것 확인했습니다.
- **증빙자료:** (Postman 응답 결과 캡쳐본 첨부 또는 JSON 응답 복사)
<img width="1108" height="205" alt="image" src="https://github.com/user-attachments/assets/3a3b4427-c834-46cd-a055-297b2e4308fa" />
<img width="1107" height="191" alt="image" src="https://github.com/user-attachments/assets/792c257a-7df3-4231-8f7b-bf773390dc27" />

## ✅ 체크리스트
- [x] 코드 컨벤션(Checkstyle/Spotless)을 준수했는가?
- [x] 빌드가 성공적으로 수행되는가? (`./gradlew build`)
- [x] 불필요한 주석이나 print문은 제거했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 새로고침 토큰 쿠키의 범위를 API 인증 경로로 제한했습니다.
  * 불필요한 CSRF 쿠키 필터를 제거했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->