### PR TITLE
feat: 알림 엔드포인트 조회/삭제 구현

### DIFF
--- a/mopl-api/src/main/java/io/mopl/api/notification/controller/NotificationController.java
+++ b/mopl-api/src/main/java/io/mopl/api/notification/controller/NotificationController.java
@@ -1,0 +1,40 @@
+package io.mopl.api.notification.controller;
+
+import io.mopl.api.common.dto.CursorResponse;
+import io.mopl.api.notification.dto.NotificationDto;
+import io.mopl.api.notification.dto.NotificationSearchRequest;
+import io.mopl.api.notification.service.NotificationService;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notifications")
+public class NotificationController {
+
+  private final NotificationService notificationService;
+
+  @GetMapping
+  public ResponseEntity<CursorResponse<NotificationDto>> list(
+      @AuthenticationPrincipal(expression = "userId") UUID userId,
+      @ModelAttribute @Valid NotificationSearchRequest request) {
+    return ResponseEntity.ok(notificationService.findUnread(userId, request));
+  }
+
+  @DeleteMapping("/{notificationId}")
+  public ResponseEntity<Void> read(
+      @PathVariable UUID notificationId,
+      @AuthenticationPrincipal(expression = "userId") UUID userId) {
+    notificationService.delete(userId, notificationId);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/mopl-api/src/main/java/io/mopl/api/notification/controller/NotificationController.java
+++ b/mopl-api/src/main/java/io/mopl/api/notification/controller/NotificationController.java
@@ -31,7 +31,7 @@ public class NotificationController {
   }
 
   @DeleteMapping("/{notificationId}")
-  public ResponseEntity<Void> read(
+  public ResponseEntity<Void> delete(
       @PathVariable UUID notificationId,
       @AuthenticationPrincipal(expression = "userId") UUID userId) {
     notificationService.delete(userId, notificationId);

--- a/mopl-api/src/main/java/io/mopl/api/notification/domain/NotificationQueryRepository.java
+++ b/mopl-api/src/main/java/io/mopl/api/notification/domain/NotificationQueryRepository.java
@@ -1,0 +1,12 @@
+package io.mopl.api.notification.domain;
+
+import io.mopl.api.notification.dto.NotificationPage;
+import io.mopl.api.notification.dto.NotificationSearchRequest;
+import java.util.UUID;
+
+public interface NotificationQueryRepository {
+
+  NotificationPage findUnreadPage(UUID receiverId, NotificationSearchRequest request);
+
+  long countUnread(UUID receiverId);
+}

--- a/mopl-api/src/main/java/io/mopl/api/notification/domain/NotificationQueryRepositoryImpl.java
+++ b/mopl-api/src/main/java/io/mopl/api/notification/domain/NotificationQueryRepositoryImpl.java
@@ -1,0 +1,105 @@
+package io.mopl.api.notification.domain;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import io.mopl.api.common.dto.SortDirection;
+import io.mopl.api.notification.dto.NotificationPage;
+import io.mopl.api.notification.dto.NotificationSearchRequest;
+import io.mopl.core.error.BusinessException;
+import io.mopl.core.error.CommonErrorCode;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationQueryRepositoryImpl implements NotificationQueryRepository {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public NotificationPage findUnreadPage(UUID receiverId, NotificationSearchRequest request) {
+    QNotification n = QNotification.notification;
+
+    int limit = request.limit();
+    SortDirection sortDirection = request.sortDirection();
+
+    // 미읽음 알림만 조회
+    BooleanBuilder where =
+        new BooleanBuilder().and(n.receiverId.eq(receiverId)).and(n.readAt.isNull());
+
+    String cursor = request.cursor();
+    UUID idAfter = request.idAfter();
+    if (cursor != null && !cursor.isBlank()) {
+      if (idAfter == null) {
+        throw new BusinessException(CommonErrorCode.INVALID_REQUEST)
+            .addDetail("reason", "cursor requires idAfter");
+      }
+      where.and(buildCursorCondition(cursor, idAfter, sortDirection, n));
+    }
+
+    OrderSpecifier<?> primaryOrder = buildPrimaryOrder(sortDirection, n);
+    List<Notification> fetched =
+        queryFactory
+            .selectFrom(n)
+            .where(where)
+            .orderBy(
+                primaryOrder, sortDirection == SortDirection.DESCENDING ? n.id.desc() : n.id.asc())
+            .limit(limit + 1)
+            .fetch();
+
+    boolean hasNext = fetched.size() > limit;
+    if (hasNext) {
+      fetched = fetched.subList(0, limit);
+    }
+
+    String nextCursor = null;
+    UUID nextIdAfter = null;
+    if (hasNext && !fetched.isEmpty()) {
+      Notification last = fetched.get(fetched.size() - 1);
+      nextCursor = String.valueOf(last.getCreatedAt());
+      nextIdAfter = last.getId();
+    }
+
+    return new NotificationPage(fetched, hasNext, nextCursor, nextIdAfter);
+  }
+
+  @Override
+  public long countUnread(UUID receiverId) {
+    QNotification n = QNotification.notification;
+    Long count =
+        queryFactory
+            .select(n.count())
+            .from(n)
+            .where(n.receiverId.eq(receiverId).and(n.readAt.isNull()))
+            .fetchOne();
+    return count != null ? count.longValue() : 0L;
+  }
+
+  // createdAt + id 기준 커서 페이징을 적용
+  private BooleanExpression buildCursorCondition(
+      String cursor, UUID idAfter, SortDirection sortDirection, QNotification n) {
+    Instant createdAt;
+    try {
+      createdAt = Instant.parse(cursor);
+    } catch (DateTimeParseException e) {
+      throw new BusinessException(CommonErrorCode.INVALID_REQUEST)
+          .addDetail("reason", "invalid cursor format")
+          .addDetail("cursor", cursor);
+    }
+
+    if (sortDirection == SortDirection.DESCENDING) {
+      return n.createdAt.lt(createdAt).or(n.createdAt.eq(createdAt).and(n.id.lt(idAfter)));
+    }
+    return n.createdAt.gt(createdAt).or(n.createdAt.eq(createdAt).and(n.id.gt(idAfter)));
+  }
+
+  private OrderSpecifier<?> buildPrimaryOrder(SortDirection sortDirection, QNotification n) {
+    return sortDirection == SortDirection.DESCENDING ? n.createdAt.desc() : n.createdAt.asc();
+  }
+}

--- a/mopl-api/src/main/java/io/mopl/api/notification/dto/NotificationPage.java
+++ b/mopl-api/src/main/java/io/mopl/api/notification/dto/NotificationPage.java
@@ -1,0 +1,16 @@
+package io.mopl.api.notification.dto;
+
+import io.mopl.api.notification.domain.Notification;
+import java.util.List;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class NotificationPage {
+  private final List<Notification> notifications;
+  private final boolean hasNext;
+  private final String nextCursor;
+  private final UUID nextIdAfter;
+}

--- a/mopl-api/src/main/java/io/mopl/api/notification/dto/NotificationSearchRequest.java
+++ b/mopl-api/src/main/java/io/mopl/api/notification/dto/NotificationSearchRequest.java
@@ -1,0 +1,28 @@
+package io.mopl.api.notification.dto;
+
+import io.mopl.api.common.dto.SortDirection;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+import java.util.UUID;
+
+public record NotificationSearchRequest(
+    String cursor,
+    UUID idAfter,
+    @Min(value = 1, message = "{validation.limit.min}")
+        @Max(value = 100, message = "{validation.limit.max}")
+        Integer limit,
+    SortDirection sortDirection,
+    @Pattern(regexp = "createdAt", message = "{validation.sortBy.pattern}") String sortBy) {
+  public NotificationSearchRequest {
+    if (limit == null) {
+      limit = 20;
+    }
+    if (sortDirection == null) {
+      sortDirection = SortDirection.DESCENDING;
+    }
+    if (sortBy == null) {
+      sortBy = "createdAt";
+    }
+  }
+}

--- a/mopl-api/src/main/java/io/mopl/api/notification/service/NotificationService.java
+++ b/mopl-api/src/main/java/io/mopl/api/notification/service/NotificationService.java
@@ -1,0 +1,82 @@
+package io.mopl.api.notification.service;
+
+import io.mopl.api.common.dto.CursorResponse;
+import io.mopl.api.common.error.UserErrorCode;
+import io.mopl.api.notification.domain.Notification;
+import io.mopl.api.notification.domain.NotificationQueryRepository;
+import io.mopl.api.notification.domain.NotificationRepository;
+import io.mopl.api.notification.dto.NotificationDto;
+import io.mopl.api.notification.dto.NotificationSearchRequest;
+import io.mopl.core.error.BusinessException;
+import io.mopl.core.error.CommonErrorCode;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+  private final NotificationRepository notificationRepository;
+  private final NotificationQueryRepository notificationQueryRepository;
+
+  @Transactional(readOnly = true)
+  public CursorResponse<NotificationDto> findUnread(
+      UUID userId, NotificationSearchRequest request) {
+    if (userId == null) {
+      throw new BusinessException(UserErrorCode.UNAUTHORIZED);
+    }
+
+    // QueryDSL 리포지토리에서 미읽음 알림을 커서 페이징으로 조회한다.
+    var page = notificationQueryRepository.findUnreadPage(userId, request);
+    List<Notification> notifications = page.getNotifications();
+
+    List<NotificationDto> data =
+        notifications.stream()
+            .map(
+                notification ->
+                    NotificationDto.builder()
+                        .id(notification.getId())
+                        .createdAt(notification.getCreatedAt())
+                        .receiverId(notification.getReceiverId())
+                        .title(notification.getTitle())
+                        .content(notification.getContent())
+                        .level(notification.getLevel())
+                        .build())
+            .toList();
+
+    // 전체 미읽음 개수를 별도로 계산해 응답에 포함한다.
+    long totalCount = notificationQueryRepository.countUnread(userId);
+
+    return CursorResponse.<NotificationDto>builder()
+        .data(data)
+        .nextCursor(page.getNextCursor())
+        .nextIdAfter(page.getNextIdAfter())
+        .hasNext(page.isHasNext())
+        .totalCount(totalCount)
+        .sortBy(request.sortBy())
+        .sortDirection(request.sortDirection())
+        .build();
+  }
+
+  @Transactional
+  public void delete(UUID userId, UUID notificationId) {
+    if (userId == null || notificationId == null) {
+      throw new BusinessException(CommonErrorCode.INVALID_REQUEST);
+    }
+
+    // 수신자 본인의 알림만 삭제할 수 있다.
+    Notification notification =
+        notificationRepository
+            .findById(notificationId)
+            .orElseThrow(() -> new BusinessException(CommonErrorCode.NOT_FOUND));
+
+    if (!notification.getReceiverId().equals(userId)) {
+      throw new BusinessException(CommonErrorCode.FORBIDDEN);
+    }
+
+    notificationRepository.deleteById(notificationId);
+  }
+}

--- a/mopl-api/src/main/java/io/mopl/api/notification/service/NotificationService.java
+++ b/mopl-api/src/main/java/io/mopl/api/notification/service/NotificationService.java
@@ -29,7 +29,7 @@ public class NotificationService {
       throw new BusinessException(UserErrorCode.UNAUTHORIZED);
     }
 
-    // QueryDSL 리포지토리에서 미읽음 알림을 커서 페이징으로 조회한다.
+    // QueryDSL 리포지토리에서 미읽음 알림을 커서 페이징으로 조회
     var page = notificationQueryRepository.findUnreadPage(userId, request);
     List<Notification> notifications = page.getNotifications();
 
@@ -47,7 +47,7 @@ public class NotificationService {
                         .build())
             .toList();
 
-    // 전체 미읽음 개수를 별도로 계산해 응답에 포함한다.
+    // 전체 미읽음 개수를 별도로 계산해 응답에 포함
     long totalCount = notificationQueryRepository.countUnread(userId);
 
     return CursorResponse.<NotificationDto>builder()
@@ -67,7 +67,7 @@ public class NotificationService {
       throw new BusinessException(CommonErrorCode.INVALID_REQUEST);
     }
 
-    // 수신자 본인의 알림만 삭제할 수 있다.
+    // 수신자 본인의 알림만 삭제
     Notification notification =
         notificationRepository
             .findById(notificationId)


### PR DESCRIPTION
## 📌 작업 개요
- 작업 내용: 알림 조회/삭제 기능 구현
- 관련 이슈: 없음

## 🚀 주요 변경 사항
- 알림 조회 및 삭제(확인) 기능 구현
- 아직 SSE로 알림 발송 기능이 없어 Postman으로만 테스트 했습니다.

## 🛠 DB 변경 사항
- 없음

## 🧪 테스트 결과 (필수)
<img width="1130" height="838" alt="알림 조회 Postman 테스트" src="https://github.com/user-attachments/assets/1ceae9a7-9928-4f8f-bd41-9fdeececa329" />
<img width="1128" height="515" alt="알림 삭제" src="https://github.com/user-attachments/assets/bdf137da-e85a-46d1-8955-4bd1dfe080ae" />

- [x] **테스트 수행 완료**
- **테스트 시나리오:** 
- 우디 -> 버즈 팔로우 버즈 알림 발생
- 버즈로 알림 확인 (정상 조회)
- 버즈로 알림 삭제 (삭제 확인)

## ✅ 체크리스트
- [x] 코드 컨벤션(Checkstyle/Spotless)을 준수했는가?
- [x] 빌드가 성공적으로 수행되는가? (`./gradlew build`)
- [x] 불필요한 주석이나 print문은 제거했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 읽지 않은 알림 목록 조회 API 추가 — 커서 기반 페이지네이션과 정렬 지원, 다음 페이지용 커서 제공
  * 알림 삭제(읽음 처리) API 추가 — 본인 알림만 삭제 가능하도록 권한 검증 적용
  * 조회 요청 입력 검증 및 기본값 적용(한도, 정렬 기준 등)
  * 사용자별 총 미확인 알림 수 반환 지원

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->