### PR TITLE
feat: DM/ 시청시작 알림 이벤트 발행까지 구현

### DIFF
--- a/mopl-api/src/main/java/io/mopl/api/common/config/SecurityConfig.java
+++ b/mopl-api/src/main/java/io/mopl/api/common/config/SecurityConfig.java
@@ -196,13 +196,12 @@ public class SecurityConfig {
                     .authenticated()
 
                     /* ========== 시청 세션 관리 ========== */
-                    // 관리자: 전체 기능
+                    // 유저: 시청 세션 조회
                     .requestMatchers(
                         HttpMethod.GET,
                         "/api/users/{watcherId}/watching-sessions",
                         "/api/contents/{contentId}/watching-sessions")
                     .authenticated()
-                    //                    .hasRole("ADMIN")
 
                     /* ========== SSE ========== */
                     // 유저: 전체 기능

--- a/mopl-api/src/main/java/io/mopl/api/common/config/SecurityConfig.java
+++ b/mopl-api/src/main/java/io/mopl/api/common/config/SecurityConfig.java
@@ -201,7 +201,8 @@ public class SecurityConfig {
                         HttpMethod.GET,
                         "/api/users/{watcherId}/watching-sessions",
                         "/api/contents/{contentId}/watching-sessions")
-                    .hasRole("ADMIN")
+                    .authenticated()
+                    //                    .hasRole("ADMIN")
 
                     /* ========== SSE ========== */
                     // 유저: 전체 기능

--- a/mopl-core/src/main/java/io/mopl/core/event/dm/DirectMessageReceivedEvent.java
+++ b/mopl-core/src/main/java/io/mopl/core/event/dm/DirectMessageReceivedEvent.java
@@ -1,0 +1,12 @@
+package io.mopl.core.event.dm;
+
+import java.time.Instant;
+
+public record DirectMessageReceivedEvent(
+    String eventId,
+    Instant occurredAt,
+    String conversationId,
+    String senderId,
+    String senderName,
+    String receiverId,
+    String content) {}

--- a/mopl-core/src/main/java/io/mopl/core/event/watching/WatchingSessionStartedEvent.java
+++ b/mopl-core/src/main/java/io/mopl/core/event/watching/WatchingSessionStartedEvent.java
@@ -1,0 +1,6 @@
+package io.mopl.core.event.watching;
+
+import java.time.Instant;
+
+public record WatchingSessionStartedEvent(
+    String eventId, Instant occurredAt, String watcherId, String watcherName, String contentId) {}

--- a/mopl-socket/src/main/java/io/mopl/socket/watching/WatchingSessionEventListener.java
+++ b/mopl-socket/src/main/java/io/mopl/socket/watching/WatchingSessionEventListener.java
@@ -78,7 +78,18 @@ public class WatchingSessionEventListener {
             socketUser.userId().toString(),
             socketUser.name(),
             contentId);
-    kafkaTemplate.send(KafkaTopics.WATCHING_SESSION_STARTED, contentId, startedEvent);
+    kafkaTemplate
+        .send(KafkaTopics.WATCHING_SESSION_STARTED, contentId, startedEvent)
+        .whenComplete(
+            (result, ex) -> {
+              if (ex != null) {
+                log.warn(
+                    "시청 시작 알림 이벤트 발행 실패: contentId={}, watcherId={}",
+                    contentId,
+                    socketUser.userId(),
+                    ex);
+              }
+            });
 
     WatchingSessionChange change =
         WatchingSessionChange.builder()

--- a/mopl-socket/src/main/java/io/mopl/socket/watching/WatchingSessionEventListener.java
+++ b/mopl-socket/src/main/java/io/mopl/socket/watching/WatchingSessionEventListener.java
@@ -1,5 +1,7 @@
 package io.mopl.socket.watching;
 
+import io.mopl.core.event.watching.WatchingSessionStartedEvent;
+import io.mopl.core.kafka.KafkaTopics;
 import io.mopl.socket.content.dto.ContentSummary;
 import io.mopl.socket.user.dto.UserSummary;
 import io.mopl.socket.watching.dto.ChangeType;
@@ -16,6 +18,7 @@ import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -36,6 +39,7 @@ public class WatchingSessionEventListener {
   private final WatchingSessionService watchingSessionService;
   private final SimpMessagingTemplate messagingTemplate;
   private final SessionSubscriptionRegistry subscriptionRegistry;
+  private final KafkaTemplate<String, Object> kafkaTemplate;
 
   @EventListener
   public void handleSubscribe(SessionSubscribeEvent event) {
@@ -65,6 +69,16 @@ public class WatchingSessionEventListener {
     long watcherCount =
         watchingSessionService.join(
             contentId, socketUser.userId(), socketUser.name(), socketUser.profileImageUrl());
+
+    // 시청 시작 알림 이벤트를 Kafka로 발행한다.
+    WatchingSessionStartedEvent startedEvent =
+        new WatchingSessionStartedEvent(
+            UUID.randomUUID().toString(),
+            Instant.now(),
+            socketUser.userId().toString(),
+            socketUser.name(),
+            contentId);
+    kafkaTemplate.send(KafkaTopics.WATCHING_SESSION_STARTED, contentId, startedEvent);
 
     WatchingSessionChange change =
         WatchingSessionChange.builder()

--- a/mopl-worker/src/main/java/io/mopl/worker/conversation/DirectMessagePostProcessor.java
+++ b/mopl-worker/src/main/java/io/mopl/worker/conversation/DirectMessagePostProcessor.java
@@ -2,6 +2,7 @@ package io.mopl.worker.conversation;
 
 import io.mopl.core.error.BusinessException;
 import io.mopl.core.event.conversation.DirectMessageCreatedEvent;
+import io.mopl.core.event.dm.DirectMessageReceivedEvent;
 import io.mopl.core.kafka.KafkaTopics;
 import io.mopl.worker.common.WorkerErrorCode;
 import io.mopl.worker.conversation.domain.DirectMessage;
@@ -68,6 +69,20 @@ public class DirectMessagePostProcessor {
 
     kafkaTemplate.send(
         KafkaTopics.DIRECT_MESSAGE_CREATED, event.conversationId().toString(), createdEvent);
+
+    // 알림용 DM 수신 이벤트를 함께 발행한다.
+    DirectMessageReceivedEvent receivedEvent =
+        new DirectMessageReceivedEvent(
+            event.dmId().toString(),
+            event.createdAt(),
+            event.conversationId().toString(),
+            event.senderId().toString(),
+            sender.getName(),
+            event.receiverId().toString(),
+            event.content());
+
+    kafkaTemplate.send(
+        KafkaTopics.DIRECT_MESSAGE_RECEIVED, event.receiverId().toString(), receivedEvent);
 
     // 상태 업데이트 (SENT)
     // 트랜잭션 종료 시 더티 체킹으로 업데이트됨

--- a/mopl-worker/src/main/java/io/mopl/worker/notification/DirectMessageNotificationListener.java
+++ b/mopl-worker/src/main/java/io/mopl/worker/notification/DirectMessageNotificationListener.java
@@ -1,7 +1,7 @@
 package io.mopl.worker.notification;
 
 import io.mopl.core.db.DbConstraintNames;
-import io.mopl.core.event.user.UserRoleChangedEvent;
+import io.mopl.core.event.dm.DirectMessageReceivedEvent;
 import io.mopl.core.kafka.KafkaTopics;
 import io.mopl.worker.notification.domain.Notification;
 import io.mopl.worker.notification.domain.NotificationLevel;
@@ -18,34 +18,37 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class UserRoleNotificationListener {
+public class DirectMessageNotificationListener {
 
   private final NotificationRepository notificationRepository;
   private final MessageSource messageSource;
   private final NotificationEventPublisher notificationEventPublisher;
 
-  // 사용자 권한 변경 이벤트를 수신해 알림을 저장한다.
+  // DM 수신 이벤트를 수신해 알림을 저장한다.
   @KafkaListener(
-      topics = KafkaTopics.USER_ROLE_CHANGED,
-      properties = "spring.json.value.default.type=io.mopl.core.event.user.UserRoleChangedEvent")
-  public void handle(UserRoleChangedEvent event) {
+      topics = KafkaTopics.DIRECT_MESSAGE_RECEIVED,
+      properties =
+          "spring.json.value.default.type=io.mopl.core.event.dm.DirectMessageReceivedEvent")
+  public void handle(DirectMessageReceivedEvent event) {
     try {
       UUID eventIdUuid = parseUuid(event.eventId(), "eventId", event.eventId());
-      UUID userIdUuid = parseUuid(event.userId(), "userId", event.eventId());
+      UUID receiverIdUuid = parseUuid(event.receiverId(), "receiverId", event.eventId());
 
       String title =
           messageSource.getMessage(
-              "notification.user.role-changed.title",
-              new Object[] {event.newRole()},
-              "권한이 " + event.newRole() + "(으)로 변경되었습니다.",
+              "notification.dm.received.title",
+              new Object[] {event.senderName()},
+              "새 메시지가 도착했습니다. 보낸 사람: " + event.senderName(),
               Locale.KOREAN);
+
+      String content = event.content() != null ? event.content() : "";
 
       Notification notification =
           Notification.builder()
               .eventId(eventIdUuid)
-              .receiverId(userIdUuid)
+              .receiverId(receiverIdUuid)
               .title(title)
-              .content("")
+              .content(content)
               .level(NotificationLevel.INFO)
               .build();
       Notification saved = notificationRepository.save(notification);
@@ -74,7 +77,7 @@ public class UserRoleNotificationListener {
     try {
       return UUID.fromString(value);
     } catch (IllegalArgumentException e) {
-      log.error("UUID 형식이 올바르지 않습니다. 필드: {} (eventId={})", fieldName, eventId, e);
+      log.error("UUID 형식이 올바르지 않습니다: {} (eventId={})", fieldName, eventId, e);
       throw e;
     }
   }

--- a/mopl-worker/src/main/java/io/mopl/worker/notification/DirectMessageNotificationListener.java
+++ b/mopl-worker/src/main/java/io/mopl/worker/notification/DirectMessageNotificationListener.java
@@ -1,6 +1,5 @@
 package io.mopl.worker.notification;
 
-import io.mopl.core.db.DbConstraintNames;
 import io.mopl.core.event.dm.DirectMessageReceivedEvent;
 import io.mopl.core.kafka.KafkaTopics;
 import io.mopl.worker.notification.domain.Notification;
@@ -31,8 +30,11 @@ public class DirectMessageNotificationListener {
           "spring.json.value.default.type=io.mopl.core.event.dm.DirectMessageReceivedEvent")
   public void handle(DirectMessageReceivedEvent event) {
     try {
-      UUID eventIdUuid = parseUuid(event.eventId(), "eventId", event.eventId());
-      UUID receiverIdUuid = parseUuid(event.receiverId(), "receiverId", event.eventId());
+      UUID eventIdUuid =
+          NotificationListenerSupport.parseUuid(log, event.eventId(), "eventId", event.eventId());
+      UUID receiverIdUuid =
+          NotificationListenerSupport.parseUuid(
+              log, event.receiverId(), "receiverId", event.eventId());
 
       String title =
           messageSource.getMessage(
@@ -54,31 +56,9 @@ public class DirectMessageNotificationListener {
       Notification saved = notificationRepository.save(notification);
       notificationEventPublisher.publish(saved);
     } catch (DataIntegrityViolationException e) {
-      handleDataIntegrityViolation(e, event.eventId());
+      NotificationListenerSupport.handleDataIntegrityViolation(log, e, event.eventId());
     } catch (IllegalArgumentException e) {
       // UUID 파싱 오류는 parseUuid에서 로그 처리.
-    }
-  }
-
-  private void handleDataIntegrityViolation(DataIntegrityViolationException e, String eventId) {
-    Throwable cause = e.getMostSpecificCause();
-    String message = cause != null ? cause.getMessage() : e.getMessage();
-
-    if (message != null && message.contains(DbConstraintNames.UQ_NOTIFICATIONS_EVENT_ID)) {
-      log.debug("중복 이벤트 무시 (eventId={})", eventId);
-    } else if (message != null && message.contains(DbConstraintNames.FK_NOTIFICATIONS_RECEIVER)) {
-      log.error("수신자 참조 오류 (eventId={})", eventId, e);
-    } else {
-      log.error("알림 저장 중 오류 (eventId={})", eventId, e);
-    }
-  }
-
-  private UUID parseUuid(String value, String fieldName, String eventId) {
-    try {
-      return UUID.fromString(value);
-    } catch (IllegalArgumentException e) {
-      log.error("UUID 형식이 올바르지 않습니다: {} (eventId={})", fieldName, eventId, e);
-      throw e;
     }
   }
 }

--- a/mopl-worker/src/main/java/io/mopl/worker/notification/FollowNotificationListener.java
+++ b/mopl-worker/src/main/java/io/mopl/worker/notification/FollowNotificationListener.java
@@ -1,6 +1,5 @@
 package io.mopl.worker.notification;
 
-import io.mopl.core.db.DbConstraintNames;
 import io.mopl.core.event.follow.UserFollowedEvent;
 import io.mopl.core.kafka.KafkaTopics;
 import io.mopl.worker.notification.domain.Notification;
@@ -31,8 +30,11 @@ public class FollowNotificationListener {
     try {
       log.info("팔로우 이벤트 수신: eventId={}", event.eventId());
 
-      UUID eventIdUuid = parseUuid(event.eventId(), "eventId", event.eventId());
-      UUID followeeIdUuid = parseUuid(event.followeeId(), "followeeId", event.eventId());
+      UUID eventIdUuid =
+          NotificationListenerSupport.parseUuid(log, event.eventId(), "eventId", event.eventId());
+      UUID followeeIdUuid =
+          NotificationListenerSupport.parseUuid(
+              log, event.followeeId(), "followeeId", event.eventId());
 
       String title =
           messageSource.getMessage(
@@ -52,28 +54,10 @@ public class FollowNotificationListener {
       Notification saved = notificationRepository.save(notification);
       notificationEventPublisher.publish(saved);
     } catch (DataIntegrityViolationException e) {
-      Throwable cause = e.getMostSpecificCause();
-      String message = cause != null ? cause.getMessage() : e.getMessage();
-
-      if (message != null && message.contains(DbConstraintNames.UQ_NOTIFICATIONS_EVENT_ID)) {
-        // 이미 처리된 이벤트는 무시한다.
-        log.debug("중복 이벤트 무시 (eventId={})", event.eventId());
-      } else if (message != null && message.contains(DbConstraintNames.FK_NOTIFICATIONS_RECEIVER)) {
-        log.error("수신자 참조 오류 (eventId={})", event.eventId(), e);
-      } else {
-        log.error("알림 저장 중 오류 (eventId={})", event.eventId(), e);
-      }
+      // 이미 처리된 이벤트는 무시한다.
+      NotificationListenerSupport.handleDataIntegrityViolation(log, e, event.eventId());
     } catch (IllegalArgumentException e) {
       // UUID 파싱 오류는 parseUuid에서 로그 처리.
-    }
-  }
-
-  private UUID parseUuid(String value, String fieldName, String eventId) {
-    try {
-      return UUID.fromString(value);
-    } catch (IllegalArgumentException e) {
-      log.error("UUID 형식이 올바르지 않습니다: {} (eventId={})", fieldName, eventId, e);
-      throw e;
     }
   }
 }

--- a/mopl-worker/src/main/java/io/mopl/worker/notification/FollowNotificationListener.java
+++ b/mopl-worker/src/main/java/io/mopl/worker/notification/FollowNotificationListener.java
@@ -13,7 +13,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.MessageSource;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.kafka.annotation.KafkaListener;
-import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -28,7 +27,7 @@ public class FollowNotificationListener {
   @KafkaListener(
       topics = KafkaTopics.USER_FOLLOWED,
       properties = "spring.json.value.default.type=io.mopl.core.event.follow.UserFollowedEvent")
-  public void handle(UserFollowedEvent event, Acknowledgment acknowledgment) {
+  public void handle(UserFollowedEvent event) {
     try {
       log.info("팔로우 이벤트 수신: eventId={}", event.eventId());
 
@@ -39,7 +38,7 @@ public class FollowNotificationListener {
           messageSource.getMessage(
               "notification.follow.title",
               new Object[] {event.followerName()},
-              "새 팔로워: " + event.followerName(),
+              "새 팔로우: " + event.followerName(),
               Locale.KOREAN);
 
       Notification notification =
@@ -65,9 +64,7 @@ public class FollowNotificationListener {
         log.error("알림 저장 중 오류 (eventId={})", event.eventId(), e);
       }
     } catch (IllegalArgumentException e) {
-      // UUID 파싱 오류는 parseUuid에서 로깅한다.
-    } finally {
-      acknowledgment.acknowledge();
+      // UUID 파싱 오류는 parseUuid에서 로그 처리.
     }
   }
 

--- a/mopl-worker/src/main/java/io/mopl/worker/notification/NotificationListenerSupport.java
+++ b/mopl-worker/src/main/java/io/mopl/worker/notification/NotificationListenerSupport.java
@@ -1,0 +1,38 @@
+package io.mopl.worker.notification;
+
+import io.mopl.core.db.DbConstraintNames;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.slf4j.Logger;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class NotificationListenerSupport {
+
+  static void handleDataIntegrityViolation(
+      Logger log, DataIntegrityViolationException e, String eventId) {
+    Throwable cause = e.getMostSpecificCause();
+    String message = cause != null ? cause.getMessage() : e.getMessage();
+
+    if (message != null && message.contains(DbConstraintNames.UQ_NOTIFICATIONS_EVENT_ID)) {
+      log.debug("중복 이벤트 무시 (eventId={})", eventId);
+    } else if (message != null && message.contains(DbConstraintNames.FK_NOTIFICATIONS_RECEIVER)) {
+      log.error("수신자 참조 오류 (eventId={})", eventId, e);
+    } else {
+      log.error("알림 저장 중 오류 (eventId={})", eventId, e);
+    }
+  }
+
+  static UUID parseUuid(Logger log, String value, String fieldName, String eventId) {
+    try {
+      if (value == null || value.isBlank()) {
+        throw new IllegalArgumentException("value is null/blank");
+      }
+      return UUID.fromString(value);
+    } catch (IllegalArgumentException e) {
+      log.error("UUID 형식이 올바르지 않습니다: {} (eventId={})", fieldName, eventId, e);
+      throw e;
+    }
+  }
+}

--- a/mopl-worker/src/main/java/io/mopl/worker/notification/PlaylistNotificationListener.java
+++ b/mopl-worker/src/main/java/io/mopl/worker/notification/PlaylistNotificationListener.java
@@ -17,7 +17,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.MessageSource;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.kafka.annotation.KafkaListener;
-import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -30,12 +29,12 @@ public class PlaylistNotificationListener {
   private final MessageSource messageSource;
   private final NotificationEventPublisher notificationEventPublisher;
 
-  // 플레이리스트 구독 이벤트를 소비해 소유자에게 알림을 저장한다.
+  // 플레이리스트 구독 이벤트를 소유자에게 알림으로 저장한다.
   @KafkaListener(
       topics = KafkaTopics.PLAYLIST_SUBSCRIBED,
       properties =
           "spring.json.value.default.type=io.mopl.core.event.playlist.PlaylistSubscribedEvent")
-  public void handleSubscribed(PlaylistSubscribedEvent event, Acknowledgment acknowledgment) {
+  public void handleSubscribed(PlaylistSubscribedEvent event) {
     try {
       UUID eventIdUuid = parseUuid(event.eventId(), "eventId", event.eventId());
       UUID ownerIdUuid = parseUuid(event.ownerId(), "ownerId", event.eventId());
@@ -60,18 +59,16 @@ public class PlaylistNotificationListener {
     } catch (DataIntegrityViolationException e) {
       handleDataIntegrityViolation(e, event.eventId());
     } catch (IllegalArgumentException e) {
-      // UUID 파싱 오류는 parseUuid에서 로깅한다.
-    } finally {
-      acknowledgment.acknowledge();
+      // UUID 파싱 오류는 parseUuid에서 로그 처리.
     }
   }
 
-  // 플레이리스트 콘텐츠 추가 이벤트를 소비해 구독자에게 알림을 저장한다.
+  // 플레이리스트 콘텐츠 추가 이벤트를 구독자에게 알림으로 저장한다.
   @KafkaListener(
       topics = KafkaTopics.PLAYLIST_CONTENT_ADDED,
       properties =
           "spring.json.value.default.type=io.mopl.core.event.playlist.PlaylistContentAddedEvent")
-  public void handleContentAdded(PlaylistContentAddedEvent event, Acknowledgment acknowledgment) {
+  public void handleContentAdded(PlaylistContentAddedEvent event) {
     try {
       UUID playlistIdUuid = parseUuid(event.playlistId(), "playlistId", event.eventId());
 
@@ -85,7 +82,7 @@ public class PlaylistNotificationListener {
       List<UUID> receiverIds = recipientQuery.findSubscriberIds(playlistIdUuid);
       for (UUID receiverId : receiverIds) {
         try {
-          // 수신자별로 event_id를 분리해 유니크 제약 충돌을 방지한다.
+          // 수신자별로 event_id를 분리해 중복 충돌을 방지한다.
           UUID eventIdUuid = toPerReceiverEventId(event.eventId(), receiverId);
           Notification notification =
               Notification.builder()
@@ -102,18 +99,16 @@ public class PlaylistNotificationListener {
         }
       }
     } catch (IllegalArgumentException e) {
-      // UUID 파싱 오류는 parseUuid에서 로깅한다.
-    } finally {
-      acknowledgment.acknowledge();
+      // UUID 파싱 오류는 parseUuid에서 로그 처리.
     }
   }
 
-  // 플레이리스트 생성 이벤트를 소비해 팔로워에게 알림을 저장한다.
+  // 플레이리스트 생성 이벤트를 팔로워에게 알림으로 저장한다.
   @KafkaListener(
       topics = KafkaTopics.PLAYLIST_CREATED,
       properties =
           "spring.json.value.default.type=io.mopl.core.event.playlist.PlaylistCreatedEvent")
-  public void handleCreated(PlaylistCreatedEvent event, Acknowledgment acknowledgment) {
+  public void handleCreated(PlaylistCreatedEvent event) {
     try {
       UUID ownerIdUuid = parseUuid(event.ownerId(), "ownerId", event.eventId());
 
@@ -127,7 +122,7 @@ public class PlaylistNotificationListener {
       List<UUID> receiverIds = recipientQuery.findFollowerIds(ownerIdUuid);
       for (UUID receiverId : receiverIds) {
         try {
-          // 수신자별로 event_id를 분리해 유니크 제약 충돌을 방지한다.
+          // 수신자별로 event_id를 분리해 중복 충돌을 방지한다.
           UUID eventIdUuid = toPerReceiverEventId(event.eventId(), receiverId);
           Notification notification =
               Notification.builder()
@@ -144,9 +139,7 @@ public class PlaylistNotificationListener {
         }
       }
     } catch (IllegalArgumentException e) {
-      // UUID 파싱 오류는 parseUuid에서 로깅한다.
-    } finally {
-      acknowledgment.acknowledge();
+      // UUID 파싱 오류는 parseUuid에서 로그 처리.
     }
   }
 

--- a/mopl-worker/src/main/java/io/mopl/worker/notification/PlaylistNotificationListener.java
+++ b/mopl-worker/src/main/java/io/mopl/worker/notification/PlaylistNotificationListener.java
@@ -1,6 +1,5 @@
 package io.mopl.worker.notification;
 
-import io.mopl.core.db.DbConstraintNames;
 import io.mopl.core.event.playlist.PlaylistContentAddedEvent;
 import io.mopl.core.event.playlist.PlaylistCreatedEvent;
 import io.mopl.core.event.playlist.PlaylistSubscribedEvent;
@@ -36,8 +35,10 @@ public class PlaylistNotificationListener {
           "spring.json.value.default.type=io.mopl.core.event.playlist.PlaylistSubscribedEvent")
   public void handleSubscribed(PlaylistSubscribedEvent event) {
     try {
-      UUID eventIdUuid = parseUuid(event.eventId(), "eventId", event.eventId());
-      UUID ownerIdUuid = parseUuid(event.ownerId(), "ownerId", event.eventId());
+      UUID eventIdUuid =
+          NotificationListenerSupport.parseUuid(log, event.eventId(), "eventId", event.eventId());
+      UUID ownerIdUuid =
+          NotificationListenerSupport.parseUuid(log, event.ownerId(), "ownerId", event.eventId());
 
       String title =
           messageSource.getMessage(
@@ -57,7 +58,7 @@ public class PlaylistNotificationListener {
       Notification saved = notificationRepository.save(notification);
       notificationEventPublisher.publish(saved);
     } catch (DataIntegrityViolationException e) {
-      handleDataIntegrityViolation(e, event.eventId());
+      NotificationListenerSupport.handleDataIntegrityViolation(log, e, event.eventId());
     } catch (IllegalArgumentException e) {
       // UUID 파싱 오류는 parseUuid에서 로그 처리.
     }
@@ -70,7 +71,9 @@ public class PlaylistNotificationListener {
           "spring.json.value.default.type=io.mopl.core.event.playlist.PlaylistContentAddedEvent")
   public void handleContentAdded(PlaylistContentAddedEvent event) {
     try {
-      UUID playlistIdUuid = parseUuid(event.playlistId(), "playlistId", event.eventId());
+      UUID playlistIdUuid =
+          NotificationListenerSupport.parseUuid(
+              log, event.playlistId(), "playlistId", event.eventId());
 
       String title =
           messageSource.getMessage(
@@ -95,7 +98,8 @@ public class PlaylistNotificationListener {
           Notification saved = notificationRepository.save(notification);
           notificationEventPublisher.publish(saved);
         } catch (DataIntegrityViolationException ex) {
-          handleDataIntegrityViolation(ex, event.eventId() + ":" + receiverId);
+          NotificationListenerSupport.handleDataIntegrityViolation(
+              log, ex, event.eventId() + ":" + receiverId);
         }
       }
     } catch (IllegalArgumentException e) {
@@ -110,7 +114,8 @@ public class PlaylistNotificationListener {
           "spring.json.value.default.type=io.mopl.core.event.playlist.PlaylistCreatedEvent")
   public void handleCreated(PlaylistCreatedEvent event) {
     try {
-      UUID ownerIdUuid = parseUuid(event.ownerId(), "ownerId", event.eventId());
+      UUID ownerIdUuid =
+          NotificationListenerSupport.parseUuid(log, event.ownerId(), "ownerId", event.eventId());
 
       String title =
           messageSource.getMessage(
@@ -135,33 +140,12 @@ public class PlaylistNotificationListener {
           Notification saved = notificationRepository.save(notification);
           notificationEventPublisher.publish(saved);
         } catch (DataIntegrityViolationException ex) {
-          handleDataIntegrityViolation(ex, event.eventId() + ":" + receiverId);
+          NotificationListenerSupport.handleDataIntegrityViolation(
+              log, ex, event.eventId() + ":" + receiverId);
         }
       }
     } catch (IllegalArgumentException e) {
       // UUID 파싱 오류는 parseUuid에서 로그 처리.
-    }
-  }
-
-  private void handleDataIntegrityViolation(DataIntegrityViolationException e, String eventId) {
-    Throwable cause = e.getMostSpecificCause();
-    String message = cause != null ? cause.getMessage() : e.getMessage();
-
-    if (message != null && message.contains(DbConstraintNames.UQ_NOTIFICATIONS_EVENT_ID)) {
-      log.debug("중복 이벤트 무시 (eventId={})", eventId);
-    } else if (message != null && message.contains(DbConstraintNames.FK_NOTIFICATIONS_RECEIVER)) {
-      log.error("수신자 참조 오류 (eventId={})", eventId, e);
-    } else {
-      log.error("알림 저장 중 오류 (eventId={})", eventId, e);
-    }
-  }
-
-  private UUID parseUuid(String value, String fieldName, String eventId) {
-    try {
-      return UUID.fromString(value);
-    } catch (IllegalArgumentException e) {
-      log.error("UUID 형식이 올바르지 않습니다: {} (eventId={})", fieldName, eventId, e);
-      throw e;
     }
   }
 

--- a/mopl-worker/src/main/java/io/mopl/worker/notification/UserRoleNotificationListener.java
+++ b/mopl-worker/src/main/java/io/mopl/worker/notification/UserRoleNotificationListener.java
@@ -1,6 +1,5 @@
 package io.mopl.worker.notification;
 
-import io.mopl.core.db.DbConstraintNames;
 import io.mopl.core.event.user.UserRoleChangedEvent;
 import io.mopl.core.kafka.KafkaTopics;
 import io.mopl.worker.notification.domain.Notification;
@@ -30,8 +29,10 @@ public class UserRoleNotificationListener {
       properties = "spring.json.value.default.type=io.mopl.core.event.user.UserRoleChangedEvent")
   public void handle(UserRoleChangedEvent event) {
     try {
-      UUID eventIdUuid = parseUuid(event.eventId(), "eventId", event.eventId());
-      UUID userIdUuid = parseUuid(event.userId(), "userId", event.eventId());
+      UUID eventIdUuid =
+          NotificationListenerSupport.parseUuid(log, event.eventId(), "eventId", event.eventId());
+      UUID userIdUuid =
+          NotificationListenerSupport.parseUuid(log, event.userId(), "userId", event.eventId());
 
       String title =
           messageSource.getMessage(
@@ -51,31 +52,9 @@ public class UserRoleNotificationListener {
       Notification saved = notificationRepository.save(notification);
       notificationEventPublisher.publish(saved);
     } catch (DataIntegrityViolationException e) {
-      handleDataIntegrityViolation(e, event.eventId());
+      NotificationListenerSupport.handleDataIntegrityViolation(log, e, event.eventId());
     } catch (IllegalArgumentException e) {
       // UUID 파싱 오류는 parseUuid에서 로그 처리.
-    }
-  }
-
-  private void handleDataIntegrityViolation(DataIntegrityViolationException e, String eventId) {
-    Throwable cause = e.getMostSpecificCause();
-    String message = cause != null ? cause.getMessage() : e.getMessage();
-
-    if (message != null && message.contains(DbConstraintNames.UQ_NOTIFICATIONS_EVENT_ID)) {
-      log.debug("중복 이벤트 무시 (eventId={})", eventId);
-    } else if (message != null && message.contains(DbConstraintNames.FK_NOTIFICATIONS_RECEIVER)) {
-      log.error("수신자 참조 오류 (eventId={})", eventId, e);
-    } else {
-      log.error("알림 저장 중 오류 (eventId={})", eventId, e);
-    }
-  }
-
-  private UUID parseUuid(String value, String fieldName, String eventId) {
-    try {
-      return UUID.fromString(value);
-    } catch (IllegalArgumentException e) {
-      log.error("UUID 형식이 올바르지 않습니다. 필드: {} (eventId={})", fieldName, eventId, e);
-      throw e;
     }
   }
 }

--- a/mopl-worker/src/main/java/io/mopl/worker/notification/WatchingSessionNotificationListener.java
+++ b/mopl-worker/src/main/java/io/mopl/worker/notification/WatchingSessionNotificationListener.java
@@ -1,6 +1,5 @@
 package io.mopl.worker.notification;
 
-import io.mopl.core.db.DbConstraintNames;
 import io.mopl.core.event.watching.WatchingSessionStartedEvent;
 import io.mopl.core.kafka.KafkaTopics;
 import io.mopl.worker.notification.domain.Notification;
@@ -34,8 +33,12 @@ public class WatchingSessionNotificationListener {
           "spring.json.value.default.type=io.mopl.core.event.watching.WatchingSessionStartedEvent")
   public void handle(WatchingSessionStartedEvent event) {
     try {
-      UUID watcherIdUuid = parseUuid(event.watcherId(), "watcherId", event.eventId());
-      UUID contentIdUuid = parseUuid(event.contentId(), "contentId", event.eventId());
+      UUID watcherIdUuid =
+          NotificationListenerSupport.parseUuid(
+              log, event.watcherId(), "watcherId", event.eventId());
+      UUID contentIdUuid =
+          NotificationListenerSupport.parseUuid(
+              log, event.contentId(), "contentId", event.eventId());
 
       String contentTitle = recipientQuery.findContentTitle(contentIdUuid);
       if (contentTitle == null || contentTitle.isBlank()) {
@@ -65,7 +68,8 @@ public class WatchingSessionNotificationListener {
           Notification saved = notificationRepository.save(notification);
           notificationEventPublisher.publish(saved);
         } catch (DataIntegrityViolationException ex) {
-          handleDataIntegrityViolation(ex, event.eventId() + ":" + receiverId);
+          NotificationListenerSupport.handleDataIntegrityViolation(
+              log, ex, event.eventId() + ":" + receiverId);
         }
       }
     } catch (IllegalArgumentException e) {
@@ -76,27 +80,5 @@ public class WatchingSessionNotificationListener {
   private UUID toPerReceiverEventId(String eventId, UUID receiverId) {
     String source = eventId + ":" + receiverId;
     return UUID.nameUUIDFromBytes(source.getBytes(StandardCharsets.UTF_8));
-  }
-
-  private void handleDataIntegrityViolation(DataIntegrityViolationException e, String eventId) {
-    Throwable cause = e.getMostSpecificCause();
-    String message = cause != null ? cause.getMessage() : e.getMessage();
-
-    if (message != null && message.contains(DbConstraintNames.UQ_NOTIFICATIONS_EVENT_ID)) {
-      log.debug("중복 이벤트 무시 (eventId={})", eventId);
-    } else if (message != null && message.contains(DbConstraintNames.FK_NOTIFICATIONS_RECEIVER)) {
-      log.error("수신자 참조 오류 (eventId={})", eventId, e);
-    } else {
-      log.error("알림 저장 중 오류 (eventId={})", eventId, e);
-    }
-  }
-
-  private UUID parseUuid(String value, String fieldName, String eventId) {
-    try {
-      return UUID.fromString(value);
-    } catch (IllegalArgumentException e) {
-      log.error("UUID 형식이 올바르지 않습니다: {} (eventId={})", fieldName, eventId, e);
-      throw e;
-    }
   }
 }

--- a/mopl-worker/src/main/java/io/mopl/worker/notification/WatchingSessionNotificationListener.java
+++ b/mopl-worker/src/main/java/io/mopl/worker/notification/WatchingSessionNotificationListener.java
@@ -1,0 +1,102 @@
+package io.mopl.worker.notification;
+
+import io.mopl.core.db.DbConstraintNames;
+import io.mopl.core.event.watching.WatchingSessionStartedEvent;
+import io.mopl.core.kafka.KafkaTopics;
+import io.mopl.worker.notification.domain.Notification;
+import io.mopl.worker.notification.domain.NotificationLevel;
+import io.mopl.worker.notification.domain.NotificationRepository;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.MessageSource;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WatchingSessionNotificationListener {
+
+  private final NotificationRepository notificationRepository;
+  private final NotificationRecipientQuery recipientQuery;
+  private final MessageSource messageSource;
+  private final NotificationEventPublisher notificationEventPublisher;
+
+  // 시청 시작 이벤트를 팔로워에게 알림으로 저장한다.
+  @KafkaListener(
+      topics = KafkaTopics.WATCHING_SESSION_STARTED,
+      properties =
+          "spring.json.value.default.type=io.mopl.core.event.watching.WatchingSessionStartedEvent")
+  public void handle(WatchingSessionStartedEvent event) {
+    try {
+      UUID watcherIdUuid = parseUuid(event.watcherId(), "watcherId", event.eventId());
+      UUID contentIdUuid = parseUuid(event.contentId(), "contentId", event.eventId());
+
+      String contentTitle = recipientQuery.findContentTitle(contentIdUuid);
+      if (contentTitle == null || contentTitle.isBlank()) {
+        contentTitle = "알 수 없는 콘텐츠";
+      }
+
+      String title =
+          messageSource.getMessage(
+              "notification.watching.started.title",
+              new Object[] {event.watcherName(), contentTitle},
+              event.watcherName() + "님이 " + contentTitle + " 시청을 시작했습니다.",
+              Locale.KOREAN);
+
+      List<UUID> receiverIds = recipientQuery.findFollowerIds(watcherIdUuid);
+      for (UUID receiverId : receiverIds) {
+        try {
+          // 수신자별로 event_id를 분리해 중복 충돌을 방지한다.
+          UUID eventIdUuid = toPerReceiverEventId(event.eventId(), receiverId);
+          Notification notification =
+              Notification.builder()
+                  .eventId(eventIdUuid)
+                  .receiverId(receiverId)
+                  .title(title)
+                  .content("")
+                  .level(NotificationLevel.INFO)
+                  .build();
+          Notification saved = notificationRepository.save(notification);
+          notificationEventPublisher.publish(saved);
+        } catch (DataIntegrityViolationException ex) {
+          handleDataIntegrityViolation(ex, event.eventId() + ":" + receiverId);
+        }
+      }
+    } catch (IllegalArgumentException e) {
+      // UUID 파싱 오류는 parseUuid에서 로그 처리.
+    }
+  }
+
+  private UUID toPerReceiverEventId(String eventId, UUID receiverId) {
+    String source = eventId + ":" + receiverId;
+    return UUID.nameUUIDFromBytes(source.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private void handleDataIntegrityViolation(DataIntegrityViolationException e, String eventId) {
+    Throwable cause = e.getMostSpecificCause();
+    String message = cause != null ? cause.getMessage() : e.getMessage();
+
+    if (message != null && message.contains(DbConstraintNames.UQ_NOTIFICATIONS_EVENT_ID)) {
+      log.debug("중복 이벤트 무시 (eventId={})", eventId);
+    } else if (message != null && message.contains(DbConstraintNames.FK_NOTIFICATIONS_RECEIVER)) {
+      log.error("수신자 참조 오류 (eventId={})", eventId, e);
+    } else {
+      log.error("알림 저장 중 오류 (eventId={})", eventId, e);
+    }
+  }
+
+  private UUID parseUuid(String value, String fieldName, String eventId) {
+    try {
+      return UUID.fromString(value);
+    } catch (IllegalArgumentException e) {
+      log.error("UUID 형식이 올바르지 않습니다: {} (eventId={})", fieldName, eventId, e);
+      throw e;
+    }
+  }
+}


### PR DESCRIPTION
## 📌 작업 개요
- 작업 내용:  DM/ 시청시작 알림 이벤트 발행까지 구현
- 관련 이슈: 없음

## 🚀 주요 변경 사항
- SecurityConfig 시청 세션 관리 .hasRole("ADMIN")에서 .authenticated()으로 변경 (일반 유저가 화면이 뜨지 않음)
- DM + 시청 시작 시 알림 이벤트 구현

## 🛠 DB 변경 사항
- 없음

## 🧪 테스트 결과 (필수)
<img width="2335" height="770" alt="DM 이벤트 토픽 확인" src="https://github.com/user-attachments/assets/752ae0ca-98e8-4aba-99e4-449a9a822af7" />
<img width="2319" height="783" alt="실시간 시청 이벤트 발행" src="https://github.com/user-attachments/assets/e8b4b651-9d09-42ce-8cb0-26f73eee3be2" />
<img width="2319" height="783" alt="실시간 시청 이벤트 발행" src="https://github.com/user-attachments/assets/bbc74958-83d2-4692-8137-f927df0c63c1" />
<img width="1923" height="166" alt="알림 테이블 확인" src="https://github.com/user-attachments/assets/b0362511-9eb7-413c-82b6-19e1d4f9f6ba" />

- [x] **테스트 수행 완료**
- **테스트 시나리오:** 8085에 접속하여 DM과 시청 시작을 했을 때 알림 이벤트가 발행되는지 테스트

## ✅ 체크리스트
- [x] 코드 컨벤션(Checkstyle/Spotless)을 준수했는가?
- [x] 빌드가 성공적으로 수행되는가? (`./gradlew build`)
- [x] 불필요한 주석이나 print문은 제거했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 직접 메시지 수신 알림 기능 추가 — 수신자 대상 알림 생성 및 발행
  * 시청 세션 시작 알림 기능 추가 — 세션 시작 시 알림 생성 및 발행

* **Improvements**
  * 시청 세션 및 콘텐츠 조회 권한 확대: ADMIN 제한 제거, 인증 사용자 접근 허용
  * 알림 처리 흐름 개선: 중복·무결성 오류 처리 통합 및 안정성 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->