### PR TITLE
refactor: 팔로우/ 플레이리스트 / 알림 성능개선

### DIFF
--- a/initdb/00-schema.sql
+++ b/initdb/00-schema.sql
@@ -79,6 +79,9 @@ CREATE TABLE playlists (
   created_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   updated_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
   PRIMARY KEY (id),
+  KEY idx_playlists_owner_id (owner_id),
+  KEY idx_playlists_updated_id (updated_at, id),
+  KEY idx_playlists_subscriber_id (subscriber_count, id),
   CONSTRAINT fk_playlists_owner
     FOREIGN KEY (owner_id) REFERENCES users(id)
     ON DELETE CASCADE ON UPDATE CASCADE,
@@ -90,6 +93,7 @@ CREATE TABLE playlist_contents (
   content_id CHAR(36) NOT NULL,
   added_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   PRIMARY KEY (playlist_id, content_id),
+  KEY idx_playlist_contents_playlist_added (playlist_id, added_at),
   CONSTRAINT fk_playlist_contents_playlist
     FOREIGN KEY (playlist_id) REFERENCES playlists(id)
     ON DELETE CASCADE ON UPDATE CASCADE,
@@ -104,6 +108,7 @@ CREATE TABLE playlist_subscriptions (
   created_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   PRIMARY KEY (playlist_id, user_id),
   KEY idx_playlist_subscriptions_playlist_created_user (playlist_id, created_at, user_id),
+  KEY idx_playlist_subscriptions_user_playlist (user_id, playlist_id),
   CONSTRAINT fk_playlist_subscriptions_playlist
     FOREIGN KEY (playlist_id) REFERENCES playlists(id)
     ON DELETE CASCADE ON UPDATE CASCADE,

--- a/initdb/00-schema.sql
+++ b/initdb/00-schema.sql
@@ -103,6 +103,7 @@ CREATE TABLE playlist_subscriptions (
   user_id CHAR(36) NOT NULL,
   created_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   PRIMARY KEY (playlist_id, user_id),
+  KEY idx_playlist_subscriptions_playlist_created_user (playlist_id, created_at, user_id),
   CONSTRAINT fk_playlist_subscriptions_playlist
     FOREIGN KEY (playlist_id) REFERENCES playlists(id)
     ON DELETE CASCADE ON UPDATE CASCADE,
@@ -137,6 +138,7 @@ CREATE TABLE follows (
   created_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   PRIMARY KEY (id),
   UNIQUE KEY uq_follows_pair (follower_id, followee_id),
+  KEY idx_follows_followee_created_id (followee_id, created_at, id),
   CONSTRAINT fk_follows_follower
     FOREIGN KEY (follower_id) REFERENCES users(id)
     ON DELETE CASCADE ON UPDATE CASCADE,
@@ -198,6 +200,7 @@ CREATE TABLE notifications (
   read_at TIMESTAMP(6) NULL,
   PRIMARY KEY (id),
   UNIQUE KEY uq_notifications_event_id (event_id),
+  KEY idx_notifications_receiver_read_created_id (receiver_id, read_at, created_at, id),
   CONSTRAINT fk_notifications_receiver
     FOREIGN KEY (receiver_id) REFERENCES users(id)
     ON DELETE CASCADE ON UPDATE CASCADE

--- a/mopl-api/src/main/java/io/mopl/api/follow/service/FollowService.java
+++ b/mopl-api/src/main/java/io/mopl/api/follow/service/FollowService.java
@@ -1,5 +1,6 @@
 package io.mopl.api.follow.service;
 
+import io.mopl.api.common.error.UserErrorCode;
 import io.mopl.api.follow.domain.Follow;
 import io.mopl.api.follow.dto.FollowDto;
 import io.mopl.api.follow.dto.FollowRequest;
@@ -13,6 +14,7 @@ import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,32 +28,29 @@ public class FollowService {
 
   @Transactional
   public FollowDto create(@Valid FollowRequest request, UUID userId) {
-    // null값 검증
     if (userId == null || request == null || request.getFolloweeId() == null) {
       throw new BusinessException(CommonErrorCode.INVALID_REQUEST);
     }
 
     UUID followeeId = request.getFolloweeId();
-    // 자신 팔로우 막기
     if (followeeId.equals(userId)) {
       throw new BusinessException(CommonErrorCode.INVALID_REQUEST);
     }
-    // followee 존재 확인
-    userService.getUserSummary(followeeId);
+    validateIdsAndFolloweeExists(followeeId, userId);
 
-    return followRepository
-        .findByFollowerIdAndFolloweeId(userId, followeeId)
-        .map(this::toDto)
-        .orElseGet(
-            () -> {
-              UserSummary follower = userService.getUserSummary(userId);
-              Follow saved =
-                  followRepository.save(
-                      Follow.builder().followerId(userId).followeeId(followeeId).build());
-              eventPublisher.publishEvent(
-                  new FollowCreatedInternalEvent(userId, followeeId, follower.getName()));
-              return toDto(saved);
-            });
+    try {
+      Follow saved =
+          followRepository.save(Follow.builder().followerId(userId).followeeId(followeeId).build());
+      UserSummary follower = userService.getUserSummary(userId);
+      eventPublisher.publishEvent(
+          new FollowCreatedInternalEvent(userId, followeeId, follower.getName()));
+      return toDto(saved);
+    } catch (DataIntegrityViolationException e) {
+      return followRepository
+          .findByFollowerIdAndFolloweeId(userId, followeeId)
+          .map(this::toDto)
+          .orElseThrow(() -> new BusinessException(CommonErrorCode.INTERNAL_SERVER_ERROR));
+    }
   }
 
   @Transactional(readOnly = true)
@@ -86,7 +85,6 @@ public class FollowService {
     followRepository.deleteById(followId);
   }
 
-  // -- 헬퍼 메서드 --
   private FollowDto toDto(Follow follow) {
     return FollowDto.builder()
         .id(follow.getId())
@@ -99,6 +97,8 @@ public class FollowService {
     if (userId == null || followeeId == null) {
       throw new BusinessException(CommonErrorCode.INVALID_REQUEST);
     }
-    userService.getUserSummary(followeeId);
+    if (!userService.existsById(followeeId)) {
+      throw new BusinessException(UserErrorCode.USER_NOT_FOUND);
+    }
   }
 }

--- a/mopl-api/src/main/java/io/mopl/api/follow/service/FollowService.java
+++ b/mopl-api/src/main/java/io/mopl/api/follow/service/FollowService.java
@@ -6,7 +6,6 @@ import io.mopl.api.follow.dto.FollowDto;
 import io.mopl.api.follow.dto.FollowRequest;
 import io.mopl.api.follow.event.FollowCreatedInternalEvent;
 import io.mopl.api.follow.repository.FollowRepository;
-import io.mopl.api.user.dto.UserSummary;
 import io.mopl.api.user.service.UserService;
 import io.mopl.core.error.BusinessException;
 import io.mopl.core.error.CommonErrorCode;
@@ -41,9 +40,8 @@ public class FollowService {
     try {
       Follow saved =
           followRepository.save(Follow.builder().followerId(userId).followeeId(followeeId).build());
-      UserSummary follower = userService.getUserSummary(userId);
-      eventPublisher.publishEvent(
-          new FollowCreatedInternalEvent(userId, followeeId, follower.getName()));
+      String followerName = userService.getUserName(userId);
+      eventPublisher.publishEvent(new FollowCreatedInternalEvent(userId, followeeId, followerName));
       return toDto(saved);
     } catch (DataIntegrityViolationException e) {
       return followRepository

--- a/mopl-api/src/main/java/io/mopl/api/notification/service/NotificationService.java
+++ b/mopl-api/src/main/java/io/mopl/api/notification/service/NotificationService.java
@@ -9,9 +9,11 @@ import io.mopl.api.notification.dto.NotificationDto;
 import io.mopl.api.notification.dto.NotificationSearchRequest;
 import io.mopl.core.error.BusinessException;
 import io.mopl.core.error.CommonErrorCode;
+import io.mopl.redis.constants.RedisKeyPrefix;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +23,7 @@ public class NotificationService {
 
   private final NotificationRepository notificationRepository;
   private final NotificationQueryRepository notificationQueryRepository;
+  private final RedisTemplate<String, String> redisTemplate;
 
   @Transactional(readOnly = true)
   public CursorResponse<NotificationDto> findUnread(
@@ -48,7 +51,12 @@ public class NotificationService {
             .toList();
 
     // 전체 미읽음 개수를 별도로 계산해 응답에 포함
-    long totalCount = notificationQueryRepository.countUnread(userId);
+    Long cachedCount = getUnreadCountFromCache(userId);
+    long totalCount =
+        cachedCount != null ? cachedCount : notificationQueryRepository.countUnread(userId);
+    if (cachedCount == null) {
+      setUnreadCountCache(userId, totalCount);
+    }
 
     return CursorResponse.<NotificationDto>builder()
         .data(data)
@@ -78,5 +86,51 @@ public class NotificationService {
     }
 
     notificationRepository.deleteById(notificationId);
+    if (notification.getReadAt() == null) {
+      decrementUnreadCount(userId);
+    }
+  }
+
+  private Long getUnreadCountFromCache(UUID userId) {
+    String key = unreadCountKey(userId);
+    try {
+      String value = redisTemplate.opsForValue().get(key);
+      if (value == null) {
+        return null;
+      }
+      return Long.parseLong(value);
+    } catch (Exception e) {
+      redisTemplate.delete(key);
+      return null;
+    }
+  }
+
+  private void setUnreadCountCache(UUID userId, long count) {
+    String key = unreadCountKey(userId);
+    try {
+      redisTemplate.opsForValue().set(key, String.valueOf(Math.max(count, 0)));
+    } catch (Exception e) {
+      // 캐시 실패는 무시한다.
+    }
+  }
+
+  private void decrementUnreadCount(UUID userId) {
+    String key = unreadCountKey(userId);
+    try {
+      String current = redisTemplate.opsForValue().get(key);
+      if (current == null) {
+        return;
+      }
+      Long value = redisTemplate.opsForValue().increment(key, -1);
+      if (value != null && value < 0) {
+        redisTemplate.opsForValue().set(key, "0");
+      }
+    } catch (Exception e) {
+      // 캐시 실패는 무시한다.
+    }
+  }
+
+  private String unreadCountKey(UUID userId) {
+    return RedisKeyPrefix.NOTIFICATION_UNREAD_COUNT + userId;
   }
 }

--- a/mopl-api/src/main/java/io/mopl/api/notification/service/NotificationService.java
+++ b/mopl-api/src/main/java/io/mopl/api/notification/service/NotificationService.java
@@ -10,6 +10,7 @@ import io.mopl.api.notification.dto.NotificationSearchRequest;
 import io.mopl.core.error.BusinessException;
 import io.mopl.core.error.CommonErrorCode;
 import io.mopl.redis.constants.RedisKeyPrefix;
+import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class NotificationService {
+
+  private static final Duration UNREAD_COUNT_TTL = Duration.ofHours(1);
 
   private final NotificationRepository notificationRepository;
   private final NotificationQueryRepository notificationQueryRepository;
@@ -108,7 +111,7 @@ public class NotificationService {
   private void setUnreadCountCache(UUID userId, long count) {
     String key = unreadCountKey(userId);
     try {
-      redisTemplate.opsForValue().set(key, String.valueOf(Math.max(count, 0)));
+      redisTemplate.opsForValue().set(key, String.valueOf(Math.max(count, 0)), UNREAD_COUNT_TTL);
     } catch (Exception e) {
       // 캐시 실패는 무시한다.
     }

--- a/mopl-api/src/main/java/io/mopl/api/playlist/service/PlaylistQueryService.java
+++ b/mopl-api/src/main/java/io/mopl/api/playlist/service/PlaylistQueryService.java
@@ -19,6 +19,9 @@ import io.mopl.api.user.service.UserService;
 import io.mopl.core.error.BusinessException;
 import io.mopl.core.error.CommonErrorCode;
 import io.mopl.redis.constants.RedisKeyPrefix;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -47,22 +50,22 @@ public class PlaylistQueryService {
   private final UserService userService;
   private final RedisTemplate<String, String> redisTemplate;
 
-  // 플레이리스트 목록 조회
+  // 플레이리스트 목록 조회 및 응답 조립
   public CursorResponse<PlaylistDto> findPlaylists(PlaylistSearchRequest request, UUID me) {
 
-    // 정렬 기본값
+    // 정렬 기본값 결정
     String sortBy = request.getSortByOrDefault();
     String sortDirection = request.getSortDirectionOrDefault();
 
-    // 요청 객체 그대로 리포지토리 전달
+    // 페이지네이션 조회
     PlaylistPage page = playlistQueryRepository.findPlaylistsPage(request);
 
-    // totalCount는 동일 필터 조건으로 계산
+    // 동일 필터 조건으로 totalCount 계산(캐시 포함)
     long totalCount = getTotalCount(request);
 
     List<Playlist> playlists = page.getPlaylists();
 
-    // ownerId, playlistId 수집 (배치 로딩용)
+    // ownerId, playlistId 수집(배치 로딩용)
     Set<UUID> ownerIds = new HashSet<>();
     List<UUID> playlistIds = new ArrayList<>();
     for (Playlist playlist : playlists) {
@@ -70,7 +73,7 @@ public class PlaylistQueryService {
       playlistIds.add(playlist.getId());
     }
 
-    // 연관 데이터 일괄 로딩
+    // 관련 데이터 배치 로딩
     Map<UUID, UserSummary> ownerMap = playlistOwnerLoader.loadOwners(ownerIds);
     Set<UUID> subscribedPlaylistIds =
         playlistSubscriptionLoader.loadSubscribedPlaylistIdsByMe(me, playlistIds);
@@ -116,6 +119,7 @@ public class PlaylistQueryService {
         .build();
   }
 
+  // 정렬 방향 문자열 파싱
   private SortDirection parseSortDirection(String raw) {
     try {
       return SortDirection.valueOf(raw);
@@ -125,6 +129,7 @@ public class PlaylistQueryService {
     }
   }
 
+  // totalCount 캐시 조회 후 없으면 계산
   private long getTotalCount(PlaylistSearchRequest request) {
     String cacheKey = buildTotalCountCacheKey(request);
     try {
@@ -151,6 +156,7 @@ public class PlaylistQueryService {
     return totalCount;
   }
 
+  // totalCount 캐시 키 생성
   private String buildTotalCountCacheKey(PlaylistSearchRequest request) {
     String raw =
         String.join(
@@ -161,15 +167,34 @@ public class PlaylistQueryService {
     return RedisKeyPrefix.PLAYLIST_COUNT + sha256Hex(raw);
   }
 
+  // null 안전 처리
   private String nullToEmpty(String value) {
     return value == null ? "" : value;
   }
 
+  private static final ThreadLocal<MessageDigest> SHA256_DIGEST =
+      ThreadLocal.withInitial(
+          () -> {
+            try {
+              return MessageDigest.getInstance("SHA-256");
+            } catch (NoSuchAlgorithmException e) {
+              throw new IllegalStateException("SHA-256 not available", e);
+            }
+          });
+
+  // SHA-256 해시를 16진 문자열로 변환
   private String sha256Hex(String value) {
-    return Integer.toHexString(value.hashCode());
+    MessageDigest digest = SHA256_DIGEST.get();
+    digest.reset();
+    byte[] hash = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+    StringBuilder hexString = new StringBuilder(hash.length * 2);
+    for (byte b : hash) {
+      hexString.append(String.format("%02x", b));
+    }
+    return hexString.toString();
   }
 
-  // 플레이리스트 단건 조회
+  // 플레이리스트 상세 조회
   public PlaylistDto findPlaylist(UUID playlistId, UUID me) {
     Playlist playlist =
         playlistRepository

--- a/mopl-api/src/main/java/io/mopl/api/playlist/service/PlaylistQueryService.java
+++ b/mopl-api/src/main/java/io/mopl/api/playlist/service/PlaylistQueryService.java
@@ -126,7 +126,11 @@ public class PlaylistQueryService {
             .findById(playlistId)
             .orElseThrow(() -> new BusinessException(CommonErrorCode.NOT_FOUND));
 
-    UserSummary owner = userService.getUserSummary(playlist.getOwnerId());
+    Map<UUID, UserSummary> ownerMap = playlistOwnerLoader.loadOwners(Set.of(playlist.getOwnerId()));
+    UserSummary owner = ownerMap.get(playlist.getOwnerId());
+    if (owner == null) {
+      owner = userService.getUserSummary(playlist.getOwnerId());
+    }
 
     boolean subscribedByMe = false;
     if (me != null) {

--- a/mopl-api/src/main/java/io/mopl/api/playlist/service/PlaylistQueryService.java
+++ b/mopl-api/src/main/java/io/mopl/api/playlist/service/PlaylistQueryService.java
@@ -18,6 +18,11 @@ import io.mopl.api.user.dto.UserSummary;
 import io.mopl.api.user.service.UserService;
 import io.mopl.core.error.BusinessException;
 import io.mopl.core.error.CommonErrorCode;
+import io.mopl.redis.constants.RedisKeyPrefix;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -25,10 +30,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class PlaylistQueryService {
@@ -40,6 +48,7 @@ public class PlaylistQueryService {
   private final PlaylistSubscriptionRepository playlistSubscriptionRepository;
   private final PlaylistRepository playlistRepository;
   private final UserService userService;
+  private final RedisTemplate<String, String> redisTemplate;
 
   // 플레이리스트 목록 조회
   public CursorResponse<PlaylistDto> findPlaylists(PlaylistSearchRequest request, UUID me) {
@@ -52,7 +61,7 @@ public class PlaylistQueryService {
     PlaylistPage page = playlistQueryRepository.findPlaylistsPage(request);
 
     // totalCount는 동일 필터 조건으로 계산
-    long totalCount = playlistQueryRepository.countPlaylists(request);
+    long totalCount = getTotalCount(request);
 
     List<Playlist> playlists = page.getPlaylists();
 
@@ -116,6 +125,56 @@ public class PlaylistQueryService {
     } catch (IllegalArgumentException e) {
       throw new BusinessException(CommonErrorCode.INVALID_REQUEST)
           .addDetail("reason", "Invalid sortDirection. Use ASCENDING or DESCENDING.");
+    }
+  }
+
+  private long getTotalCount(PlaylistSearchRequest request) {
+    String cacheKey = buildTotalCountCacheKey(request);
+    try {
+      String cached = redisTemplate.opsForValue().get(cacheKey);
+      if (cached != null) {
+        return Long.parseLong(cached);
+      }
+    } catch (Exception e) {
+      log.warn("Redis 캐시 조회 실패 key={} error={}", cacheKey, e.getMessage());
+    }
+
+    long totalCount = playlistQueryRepository.countPlaylists(request);
+
+    try {
+      redisTemplate.opsForValue().set(cacheKey, String.valueOf(totalCount), Duration.ofMinutes(5));
+    } catch (Exception e) {
+      log.warn("Redis 캐시 저장 실패 key={} error={}", cacheKey, e.getMessage());
+    }
+
+    return totalCount;
+  }
+
+  private String buildTotalCountCacheKey(PlaylistSearchRequest request) {
+    String raw =
+        String.join(
+            "|",
+            nullToEmpty(request.getKeywordLike()),
+            String.valueOf(request.getOwnerIdEqual()),
+            String.valueOf(request.getSubscriberIdEqual()));
+    return RedisKeyPrefix.PLAYLIST_COUNT + sha256Hex(raw);
+  }
+
+  private String nullToEmpty(String value) {
+    return value == null ? "" : value;
+  }
+
+  private String sha256Hex(String value) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] bytes = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+      StringBuilder sb = new StringBuilder(bytes.length * 2);
+      for (byte b : bytes) {
+        sb.append(String.format("%02x", b));
+      }
+      return sb.toString();
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 not available", e);
     }
   }
 

--- a/mopl-api/src/main/java/io/mopl/api/playlist/service/PlaylistQueryService.java
+++ b/mopl-api/src/main/java/io/mopl/api/playlist/service/PlaylistQueryService.java
@@ -158,12 +158,15 @@ public class PlaylistQueryService {
 
   // totalCount 캐시 키 생성
   private String buildTotalCountCacheKey(PlaylistSearchRequest request) {
+    String keyword = nullToEmpty(request.getKeywordLike());
     String raw =
-        String.join(
-            "|",
-            nullToEmpty(request.getKeywordLike()),
-            String.valueOf(request.getOwnerIdEqual()),
-            String.valueOf(request.getSubscriberIdEqual()));
+        keyword.length()
+            + ":"
+            + keyword
+            + "|"
+            + String.valueOf(request.getOwnerIdEqual())
+            + "|"
+            + String.valueOf(request.getSubscriberIdEqual());
     return RedisKeyPrefix.PLAYLIST_COUNT + sha256Hex(raw);
   }
 

--- a/mopl-api/src/main/java/io/mopl/api/playlist/service/PlaylistQueryService.java
+++ b/mopl-api/src/main/java/io/mopl/api/playlist/service/PlaylistQueryService.java
@@ -19,9 +19,6 @@ import io.mopl.api.user.service.UserService;
 import io.mopl.core.error.BusinessException;
 import io.mopl.core.error.CommonErrorCode;
 import io.mopl.redis.constants.RedisKeyPrefix;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -133,7 +130,11 @@ public class PlaylistQueryService {
     try {
       String cached = redisTemplate.opsForValue().get(cacheKey);
       if (cached != null) {
-        return Long.parseLong(cached);
+        try {
+          return Long.parseLong(cached);
+        } catch (NumberFormatException e) {
+          log.warn("Redis 캐시 값 파싱 실패 key={} value={}", cacheKey, cached);
+        }
       }
     } catch (Exception e) {
       log.warn("Redis 캐시 조회 실패 key={} error={}", cacheKey, e.getMessage());
@@ -165,17 +166,7 @@ public class PlaylistQueryService {
   }
 
   private String sha256Hex(String value) {
-    try {
-      MessageDigest digest = MessageDigest.getInstance("SHA-256");
-      byte[] bytes = digest.digest(value.getBytes(StandardCharsets.UTF_8));
-      StringBuilder sb = new StringBuilder(bytes.length * 2);
-      for (byte b : bytes) {
-        sb.append(String.format("%02x", b));
-      }
-      return sb.toString();
-    } catch (NoSuchAlgorithmException e) {
-      throw new IllegalStateException("SHA-256 not available", e);
-    }
+    return Integer.toHexString(value.hashCode());
   }
 
   // 플레이리스트 단건 조회

--- a/mopl-api/src/main/java/io/mopl/api/playlist/service/PlaylistQueryService.java
+++ b/mopl-api/src/main/java/io/mopl/api/playlist/service/PlaylistQueryService.java
@@ -69,7 +69,7 @@ public class PlaylistQueryService {
     Set<UUID> subscribedPlaylistIds =
         playlistSubscriptionLoader.loadSubscribedPlaylistIdsByMe(me, playlistIds);
     Map<UUID, List<ContentSummary>> contentsMap =
-        playlistContentLoader.loadContentsByPlaylistIds(playlistIds);
+        playlistContentLoader.loadThumbnailContentsByPlaylistIds(playlistIds);
 
     // 응답 DTO 조립
     List<PlaylistDto> data = new ArrayList<>();

--- a/mopl-api/src/main/java/io/mopl/api/playlist/service/PlaylistService.java
+++ b/mopl-api/src/main/java/io/mopl/api/playlist/service/PlaylistService.java
@@ -47,6 +47,7 @@ public class PlaylistService {
   private final RedisTemplate<String, String> redisTemplate;
 
   @Transactional
+  // 플레이리스트 생성 및 생성 이벤트 발행
   public PlaylistDto create(PlaylistCreateRequest request, UUID userId) {
     if (userId == null) {
       throw new BusinessException(CommonErrorCode.INVALID_REQUEST);
@@ -79,6 +80,7 @@ public class PlaylistService {
   }
 
   @Transactional
+  // 플레이리스트 구독 처리 및 카운트 갱신
   public void subscribe(UUID playlistId, UUID userId) {
     validatePlaylistAndUserIds(playlistId, userId);
 
@@ -99,7 +101,6 @@ public class PlaylistService {
           playlistId,
           userId);
     }
-    // 커밋 후 구독 캐시 갱신
     runAfterCommit(
         () -> {
           try {
@@ -121,6 +122,7 @@ public class PlaylistService {
   }
 
   @Transactional
+  // 플레이리스트 구독 해제 및 카운트 갱신
   public void unsubscribe(UUID playlistId, UUID userId) {
     validatePlaylistAndUserIds(playlistId, userId);
 
@@ -155,6 +157,7 @@ public class PlaylistService {
   }
 
   @Transactional
+  // 플레이리스트에 콘텐츠 추가 및 캐시 무효화
   public void addContent(UUID playlistId, UUID contentId, UUID userId) {
     validatePlaylistContentInputs(playlistId, contentId, userId);
 
@@ -177,20 +180,12 @@ public class PlaylistService {
     // 커밋 후 콘텐츠 캐시 삭제
     runAfterCommit(
         () -> {
-          try {
-            String key = RedisKeyPrefix.PLAYLIST_CONTENTS + playlistId;
-            redisTemplate.delete(key);
-            redisTemplate.delete(RedisKeyPrefix.PLAYLIST_THUMBNAIL_CONTENT + playlistId);
-          } catch (Exception e) {
-            log.warn(
-                "레디스 캐시 삭제 실패 key={} error={}",
-                RedisKeyPrefix.PLAYLIST_CONTENTS + playlistId,
-                e.getMessage());
-          }
+          deletePlaylistContentCaches(playlistId);
         });
   }
 
   @Transactional
+  // 플레이리스트에서 콘텐츠 삭제 및 캐시 무효화
   public void removeContent(UUID playlistId, UUID contentId, UUID userId) {
     validatePlaylistContentInputs(playlistId, contentId, userId);
 
@@ -208,20 +203,12 @@ public class PlaylistService {
     // 커밋 후 콘텐츠 캐시 삭제
     runAfterCommit(
         () -> {
-          try {
-            String key = RedisKeyPrefix.PLAYLIST_CONTENTS + playlistId;
-            redisTemplate.delete(key);
-            redisTemplate.delete(RedisKeyPrefix.PLAYLIST_THUMBNAIL_CONTENT + playlistId);
-          } catch (Exception e) {
-            log.warn(
-                "레디스 캐시 삭제 실패 key={} error={}",
-                RedisKeyPrefix.PLAYLIST_CONTENTS + playlistId,
-                e.getMessage());
-          }
+          deletePlaylistContentCaches(playlistId);
         });
   }
 
   @Transactional
+  // 플레이리스트 삭제 및 캐시 무효화
   public void removePlaylist(UUID playlistId, UUID userId) {
     validatePlaylistAndUserIds(playlistId, userId);
 
@@ -232,20 +219,12 @@ public class PlaylistService {
     // 커밋 후 콘텐츠 캐시 삭제
     runAfterCommit(
         () -> {
-          try {
-            String key = RedisKeyPrefix.PLAYLIST_CONTENTS + playlistId;
-            redisTemplate.delete(key);
-            redisTemplate.delete(RedisKeyPrefix.PLAYLIST_THUMBNAIL_CONTENT + playlistId);
-          } catch (Exception e) {
-            log.warn(
-                "레디스 캐시 삭제 실패 key={} error={}",
-                RedisKeyPrefix.PLAYLIST_CONTENTS + playlistId,
-                e.getMessage());
-          }
+          deletePlaylistContentCaches(playlistId);
         });
   }
 
   @Transactional
+  // 플레이리스트 기본 정보 수정
   public PlaylistDto updatePlaylist(
       UUID playlistId, @Valid PlaylistUpdateRequest request, UUID userId) {
     validatePlaylistAndUserIds(playlistId, userId);
@@ -256,6 +235,16 @@ public class PlaylistService {
     playlist.update(request.getTitle(), request.getDescription());
 
     return playlistQueryService.findPlaylist(playlistId, userId);
+  }
+
+  // 플레이리스트 콘텐츠 관련 캐시 삭제
+  private void deletePlaylistContentCaches(UUID playlistId) {
+    try {
+      redisTemplate.delete(RedisKeyPrefix.PLAYLIST_CONTENTS + playlistId);
+      redisTemplate.delete(RedisKeyPrefix.PLAYLIST_THUMBNAIL_CONTENT + playlistId);
+    } catch (Exception e) {
+      log.warn("레디스 캐시 삭제 실패 playlistId={} error={}", playlistId, e.getMessage());
+    }
   }
 
   // 트랜잭션 커밋 이후에만 캐시 작업을 실행
@@ -273,30 +262,35 @@ public class PlaylistService {
     }
   }
 
+  // 플레이리스트와 사용자 식별자 검증
   private void validatePlaylistAndUserIds(UUID playlistId, UUID userId) {
     if (userId == null || playlistId == null) {
       throw new BusinessException(CommonErrorCode.INVALID_REQUEST);
     }
   }
 
+  // 플레이리스트 존재 여부 확인
   private void assertPlaylistExists(UUID playlistId) {
     if (!playlistRepository.existsById(playlistId)) {
       throw new BusinessException(CommonErrorCode.NOT_FOUND);
     }
   }
 
+  // 플레이리스트-콘텐츠 입력값 검증
   private void validatePlaylistContentInputs(UUID playlistId, UUID contentId, UUID userId) {
     if (userId == null || playlistId == null || contentId == null) {
       throw new BusinessException(CommonErrorCode.INVALID_REQUEST);
     }
   }
 
+  // 플레이리스트 조회 후 없으면 예외
   private Playlist findPlaylistOrThrow(UUID playlistId) {
     return playlistRepository
         .findById(playlistId)
         .orElseThrow(() -> new BusinessException(CommonErrorCode.NOT_FOUND));
   }
 
+  // 플레이리스트 소유자 검증
   private void assertOwner(Playlist playlist, UUID userId) {
     if (!playlist.getOwnerId().equals(userId)) {
       throw new BusinessException(CommonErrorCode.FORBIDDEN);

--- a/mopl-api/src/main/java/io/mopl/api/playlist/service/PlaylistService.java
+++ b/mopl-api/src/main/java/io/mopl/api/playlist/service/PlaylistService.java
@@ -180,6 +180,7 @@ public class PlaylistService {
           try {
             String key = RedisKeyPrefix.PLAYLIST_CONTENTS + playlistId;
             redisTemplate.delete(key);
+            redisTemplate.delete(RedisKeyPrefix.PLAYLIST_THUMBNAIL_CONTENT + playlistId);
           } catch (Exception e) {
             log.warn(
                 "레디스 캐시 삭제 실패 key={} error={}",
@@ -210,6 +211,7 @@ public class PlaylistService {
           try {
             String key = RedisKeyPrefix.PLAYLIST_CONTENTS + playlistId;
             redisTemplate.delete(key);
+            redisTemplate.delete(RedisKeyPrefix.PLAYLIST_THUMBNAIL_CONTENT + playlistId);
           } catch (Exception e) {
             log.warn(
                 "레디스 캐시 삭제 실패 key={} error={}",
@@ -233,6 +235,7 @@ public class PlaylistService {
           try {
             String key = RedisKeyPrefix.PLAYLIST_CONTENTS + playlistId;
             redisTemplate.delete(key);
+            redisTemplate.delete(RedisKeyPrefix.PLAYLIST_THUMBNAIL_CONTENT + playlistId);
           } catch (Exception e) {
             log.warn(
                 "레디스 캐시 삭제 실패 key={} error={}",

--- a/mopl-api/src/main/java/io/mopl/api/playlist/service/loader/PlaylistContentLoader.java
+++ b/mopl-api/src/main/java/io/mopl/api/playlist/service/loader/PlaylistContentLoader.java
@@ -1,6 +1,7 @@
 package io.mopl.api.playlist.service.loader;
 
 import com.querydsl.core.Tuple;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import io.mopl.api.content.domain.QContent;
 import io.mopl.api.content.domain.QContentTag;
@@ -28,6 +29,176 @@ public class PlaylistContentLoader {
 
   private final JPAQueryFactory queryFactory;
   private final RedisTemplate<String, Object> redisTemplateForObject;
+
+  public Map<UUID, List<ContentSummary>> loadThumbnailContentsByPlaylistIds(
+      List<UUID> playlistIds) {
+    if (playlistIds == null || playlistIds.isEmpty()) {
+      return Map.of();
+    }
+
+    List<UUID> playlistIdList = new ArrayList<>(playlistIds);
+    List<String> keys =
+        playlistIdList.stream().map(id -> RedisKeyPrefix.PLAYLIST_THUMBNAIL_CONTENT + id).toList();
+
+    List<Object> cached = new ArrayList<>(keys.size());
+    for (String key : keys) {
+      try {
+        cached.add(redisTemplateForObject.opsForValue().get(key));
+      } catch (Exception e) {
+        log.warn("Redis 캐시 조회 실패 key={} error={}", key, e.getMessage());
+        redisTemplateForObject.delete(key);
+        cached.add(null);
+      }
+    }
+
+    Map<UUID, List<ContentSummary>> result = new HashMap<>();
+    List<UUID> missIds = new ArrayList<>();
+
+    for (int i = 0; i < playlistIdList.size(); i++) {
+      Object value = cached.get(i);
+      if (value instanceof List<?> list) {
+        if (list.isEmpty()) {
+          result.put(playlistIdList.get(i), List.of());
+        } else if (list.get(0) instanceof ContentSummary) {
+          @SuppressWarnings("unchecked")
+          List<ContentSummary> summaries = (List<ContentSummary>) list;
+          result.put(playlistIdList.get(i), summaries);
+        } else {
+          missIds.add(playlistIdList.get(i));
+        }
+      } else {
+        missIds.add(playlistIdList.get(i));
+      }
+    }
+
+    if (missIds.isEmpty()) {
+      return result;
+    }
+
+    QPlaylistContent pc = QPlaylistContent.playlistContent;
+    QPlaylistContent pcSub = new QPlaylistContent("pcSub");
+    QContent c = QContent.content;
+
+    List<Tuple> rows =
+        queryFactory
+            .select(
+                pc.id.playlistId,
+                pc.id.contentId,
+                c.type,
+                c.title,
+                c.description,
+                c.thumbnailImageKey,
+                c.averageRating,
+                c.reviewCount)
+            .from(pc)
+            .join(c)
+            .on(pc.id.contentId.eq(c.id))
+            .where(
+                pc.id
+                    .playlistId
+                    .in(missIds)
+                    .and(
+                        pc.addedAt.eq(
+                            JPAExpressions.select(pcSub.addedAt.max())
+                                .from(pcSub)
+                                .where(pcSub.id.playlistId.eq(pc.id.playlistId)))))
+            .orderBy(pc.id.playlistId.asc(), pc.addedAt.desc())
+            .fetch();
+
+    Map<UUID, UUID> thumbnailContentIdByPlaylistId = new HashMap<>();
+    Map<UUID, ContentBase> baseByContentId = new HashMap<>();
+    Set<UUID> allContentIds = new HashSet<>();
+
+    for (Tuple row : rows) {
+      UUID playlistId = row.get(pc.id.playlistId);
+      if (thumbnailContentIdByPlaylistId.containsKey(playlistId)) {
+        continue;
+      }
+
+      UUID contentId = row.get(pc.id.contentId);
+      thumbnailContentIdByPlaylistId.put(playlistId, contentId);
+      allContentIds.add(contentId);
+
+      Double avg = row.get(c.averageRating);
+      double avgValue = avg != null ? avg.doubleValue() : 0.0d;
+      Integer reviewCount = row.get(c.reviewCount);
+
+      ContentBase base =
+          new ContentBase(
+              contentId,
+              row.get(c.type),
+              row.get(c.title),
+              row.get(c.description),
+              row.get(c.thumbnailImageKey),
+              avgValue,
+              reviewCount != null ? reviewCount.intValue() : 0);
+      baseByContentId.put(contentId, base);
+    }
+
+    if (allContentIds.isEmpty()) {
+      for (UUID playlistId : missIds) {
+        result.putIfAbsent(playlistId, List.of());
+      }
+      cacheThumbnailContents(result, missIds);
+      return result;
+    }
+
+    QContentTag ct = QContentTag.contentTag;
+    QTag t = QTag.tag;
+
+    List<Tuple> tagRows =
+        queryFactory
+            .select(ct.id.contentId, t.name)
+            .from(ct)
+            .join(t)
+            .on(ct.id.tagId.eq(t.id))
+            .where(ct.id.contentId.in(allContentIds))
+            .fetch();
+
+    Map<UUID, List<String>> tagsByContentId = new HashMap<>();
+    for (Tuple row : tagRows) {
+      UUID contentId = row.get(ct.id.contentId);
+      String tagName = row.get(t.name);
+      tagsByContentId.computeIfAbsent(contentId, k -> new ArrayList<>()).add(tagName);
+    }
+
+    Map<UUID, ContentSummary> summaryByContentId = new HashMap<>();
+    for (Map.Entry<UUID, ContentBase> entry : baseByContentId.entrySet()) {
+      UUID contentId = entry.getKey();
+      ContentBase base = entry.getValue();
+
+      List<String> tags = tagsByContentId.get(contentId);
+      if (tags == null) {
+        tags = List.of();
+      }
+
+      ContentSummary summary =
+          ContentSummary.builder()
+              .id(base.id)
+              .type(base.type)
+              .title(base.title)
+              .description(base.description)
+              .thumbnailUrl(base.thumbnailUrl)
+              .tags(tags)
+              .averageRating(base.averageRating)
+              .reviewCount(base.reviewCount)
+              .build();
+      summaryByContentId.put(contentId, summary);
+    }
+
+    for (UUID playlistId : missIds) {
+      UUID contentId = thumbnailContentIdByPlaylistId.get(playlistId);
+      if (contentId == null) {
+        result.put(playlistId, List.of());
+        continue;
+      }
+      ContentSummary summary = summaryByContentId.get(contentId);
+      result.put(playlistId, summary != null ? List.of(summary) : List.of());
+    }
+
+    cacheThumbnailContents(result, missIds);
+    return result;
+  }
 
   public Map<UUID, List<ContentSummary>> loadContentsByPlaylistIds(List<UUID> playlistIds) {
     if (playlistIds == null || playlistIds.isEmpty()) {
@@ -215,6 +386,21 @@ public class PlaylistContentLoader {
             .opsForValue()
             .set(
                 RedisKeyPrefix.PLAYLIST_CONTENTS + playlistId,
+                result.getOrDefault(playlistId, List.of()),
+                Duration.ofMinutes(30));
+      } catch (Exception e) {
+        log.debug("Redis 캐시 저장 실패 playlistId={} error={}", playlistId, e.getMessage());
+      }
+    }
+  }
+
+  private void cacheThumbnailContents(Map<UUID, List<ContentSummary>> result, List<UUID> missIds) {
+    for (UUID playlistId : missIds) {
+      try {
+        redisTemplateForObject
+            .opsForValue()
+            .set(
+                RedisKeyPrefix.PLAYLIST_THUMBNAIL_CONTENT + playlistId,
                 result.getOrDefault(playlistId, List.of()),
                 Duration.ofMinutes(30));
       } catch (Exception e) {

--- a/mopl-api/src/main/java/io/mopl/api/playlist/service/loader/PlaylistContentLoader.java
+++ b/mopl-api/src/main/java/io/mopl/api/playlist/service/loader/PlaylistContentLoader.java
@@ -40,13 +40,16 @@ public class PlaylistContentLoader {
     List<String> keys =
         playlistIdList.stream().map(id -> RedisKeyPrefix.PLAYLIST_THUMBNAIL_CONTENT + id).toList();
 
-    List<Object> cached = new ArrayList<>(keys.size());
-    for (String key : keys) {
-      try {
-        cached.add(redisTemplateForObject.opsForValue().get(key));
-      } catch (Exception e) {
-        log.warn("Redis 캐시 조회 실패 key={} error={}", key, e.getMessage());
-        redisTemplateForObject.delete(key);
+    List<Object> cached;
+    try {
+      cached = redisTemplateForObject.opsForValue().multiGet(keys);
+    } catch (Exception e) {
+      log.warn("Redis 캐시 조회 실패 keyCount={} error={}", keys.size(), e.getMessage());
+      cached = null;
+    }
+    if (cached == null) {
+      cached = new ArrayList<>(keys.size());
+      for (int i = 0; i < keys.size(); i++) {
         cached.add(null);
       }
     }
@@ -211,13 +214,16 @@ public class PlaylistContentLoader {
         playlistIdList.stream().map(id -> RedisKeyPrefix.PLAYLIST_CONTENTS + id).toList();
 
     // 개별 조회로 역직렬화 문제 키만 제거
-    List<Object> cached = new ArrayList<>(keys.size());
-    for (String key : keys) {
-      try {
-        cached.add(redisTemplateForObject.opsForValue().get(key));
-      } catch (Exception e) {
-        log.warn("Redis 캐시 조회 실패 key={} error={}", key, e.getMessage());
-        redisTemplateForObject.delete(key);
+    List<Object> cached;
+    try {
+      cached = redisTemplateForObject.opsForValue().multiGet(keys);
+    } catch (Exception e) {
+      log.warn("Redis 캐시 조회 실패 keyCount={} error={}", keys.size(), e.getMessage());
+      cached = null;
+    }
+    if (cached == null) {
+      cached = new ArrayList<>(keys.size());
+      for (int i = 0; i < keys.size(); i++) {
         cached.add(null);
       }
     }

--- a/mopl-api/src/main/java/io/mopl/api/playlist/service/loader/PlaylistContentLoader.java
+++ b/mopl-api/src/main/java/io/mopl/api/playlist/service/loader/PlaylistContentLoader.java
@@ -142,7 +142,7 @@ public class PlaylistContentLoader {
       for (UUID playlistId : missIds) {
         result.putIfAbsent(playlistId, List.of());
       }
-      cacheThumbnailContents(result, missIds);
+      cacheContents(result, missIds, RedisKeyPrefix.PLAYLIST_THUMBNAIL_CONTENT);
       return result;
     }
 
@@ -199,7 +199,7 @@ public class PlaylistContentLoader {
       result.put(playlistId, summary != null ? List.of(summary) : List.of());
     }
 
-    cacheThumbnailContents(result, missIds);
+    cacheContents(result, missIds, RedisKeyPrefix.PLAYLIST_THUMBNAIL_CONTENT);
     return result;
   }
 
@@ -310,7 +310,7 @@ public class PlaylistContentLoader {
       for (UUID playlistId : missIds) {
         result.putIfAbsent(playlistId, List.of());
       }
-      cacheContents(result, missIds);
+      cacheContents(result, missIds, RedisKeyPrefix.PLAYLIST_CONTENTS);
       return result;
     }
 
@@ -381,32 +381,18 @@ public class PlaylistContentLoader {
     }
 
     // 캐시 저장
-    cacheContents(result, missIds);
+    cacheContents(result, missIds, RedisKeyPrefix.PLAYLIST_CONTENTS);
     return result;
   }
 
-  private void cacheContents(Map<UUID, List<ContentSummary>> result, List<UUID> missIds) {
+  private void cacheContents(
+      Map<UUID, List<ContentSummary>> result, List<UUID> missIds, String keyPrefix) {
     for (UUID playlistId : missIds) {
       try {
         redisTemplateForObject
             .opsForValue()
             .set(
-                RedisKeyPrefix.PLAYLIST_CONTENTS + playlistId,
-                result.getOrDefault(playlistId, List.of()),
-                Duration.ofMinutes(30));
-      } catch (Exception e) {
-        log.debug("Redis 캐시 저장 실패 playlistId={} error={}", playlistId, e.getMessage());
-      }
-    }
-  }
-
-  private void cacheThumbnailContents(Map<UUID, List<ContentSummary>> result, List<UUID> missIds) {
-    for (UUID playlistId : missIds) {
-      try {
-        redisTemplateForObject
-            .opsForValue()
-            .set(
-                RedisKeyPrefix.PLAYLIST_THUMBNAIL_CONTENT + playlistId,
+                keyPrefix + playlistId,
                 result.getOrDefault(playlistId, List.of()),
                 Duration.ofMinutes(30));
       } catch (Exception e) {

--- a/mopl-api/src/main/java/io/mopl/api/playlist/service/loader/PlaylistSubscriptionLoader.java
+++ b/mopl-api/src/main/java/io/mopl/api/playlist/service/loader/PlaylistSubscriptionLoader.java
@@ -3,7 +3,6 @@ package io.mopl.api.playlist.service.loader;
 import io.mopl.api.playlist.domain.PlaylistSubscription;
 import io.mopl.api.playlist.domain.PlaylistSubscriptionRepository;
 import io.mopl.redis.constants.RedisKeyPrefix;
-import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -48,27 +47,17 @@ public class PlaylistSubscriptionLoader {
       // fallback to DB query below
     }
 
-    // 캐시가 없으면 사용자의 전체 구독 목록을 DB에서 조회
-    List<PlaylistSubscription> allSubs = subscriptionRepository.findByIdUserId(me);
-    Set<UUID> allSubscribedIds = new HashSet<>();
-    for (PlaylistSubscription sub : allSubs) {
-      allSubscribedIds.add(sub.getId().getPlaylistId());
-    }
-
-    // 전체 구독 목록을 Redis에 저장
-    if (!allSubscribedIds.isEmpty()) {
-      try {
-        String[] values = allSubscribedIds.stream().map(UUID::toString).toArray(String[]::new);
-        redisTemplate.opsForSet().add(key, values);
-        redisTemplate.expire(key, Duration.ofHours(6));
-      } catch (Exception e) {
-        log.warn("Redis 캐시 저장 실패 key={} error={}", key, e.getMessage());
-      }
+    // 캐시가 없으면 현재 페이지의 playlistIds만 DB에서 조회
+    List<PlaylistSubscription> subs =
+        subscriptionRepository.findByIdUserIdAndIdPlaylistIdIn(me, playlistIds);
+    Set<UUID> subscribedIds = new HashSet<>();
+    for (PlaylistSubscription sub : subs) {
+      subscribedIds.add(sub.getId().getPlaylistId());
     }
 
     // 요청된 playlistIds 중 구독된 것만 반환
     for (UUID playlistId : playlistIds) {
-      if (allSubscribedIds.contains(playlistId)) {
+      if (subscribedIds.contains(playlistId)) {
         result.add(playlistId);
       }
     }

--- a/mopl-api/src/main/java/io/mopl/api/playlist/service/loader/PlaylistSubscriptionLoader.java
+++ b/mopl-api/src/main/java/io/mopl/api/playlist/service/loader/PlaylistSubscriptionLoader.java
@@ -51,7 +51,8 @@ public class PlaylistSubscriptionLoader {
                       for (UUID playlistId : playlistIds) {
                         byte[] valueBytes = serializer.serialize(playlistId.toString());
                         if (valueBytes == null) {
-                          continue;
+                          throw new IllegalStateException(
+                              "Failed to serialize playlistId: " + playlistId);
                         }
                         connection.sIsMember(keyBytes, valueBytes);
                       }

--- a/mopl-api/src/main/java/io/mopl/api/playlist/service/loader/PlaylistSubscriptionLoader.java
+++ b/mopl-api/src/main/java/io/mopl/api/playlist/service/loader/PlaylistSubscriptionLoader.java
@@ -9,7 +9,9 @@ import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -34,10 +36,25 @@ public class PlaylistSubscriptionLoader {
     // Redis set이 존재하면 캐시에서 구독 여부를 확인
     try {
       if (Boolean.TRUE.equals(redisTemplate.hasKey(key))) {
-        for (UUID playlistId : playlistIds) {
-          Boolean isMember = redisTemplate.opsForSet().isMember(key, playlistId.toString());
-          if (Boolean.TRUE.equals(isMember)) {
-            result.add(playlistId);
+        @SuppressWarnings("unchecked")
+        RedisSerializer<String> serializer =
+            (RedisSerializer<String>) redisTemplate.getStringSerializer();
+        byte[] keyBytes = serializer.serialize(key);
+        List<Object> rawResults =
+            redisTemplate.executePipelined(
+                (RedisCallback<Object>)
+                    connection -> {
+                      for (UUID playlistId : playlistIds) {
+                        byte[] valueBytes = serializer.serialize(playlistId.toString());
+                        connection.sIsMember(keyBytes, valueBytes);
+                      }
+                      return null;
+                    });
+
+        for (int i = 0; i < playlistIds.size(); i++) {
+          Object raw = rawResults.get(i);
+          if (Boolean.TRUE.equals(raw)) {
+            result.add(playlistIds.get(i));
           }
         }
         return result;

--- a/mopl-api/src/main/java/io/mopl/api/playlist/service/loader/PlaylistSubscriptionLoader.java
+++ b/mopl-api/src/main/java/io/mopl/api/playlist/service/loader/PlaylistSubscriptionLoader.java
@@ -3,6 +3,7 @@ package io.mopl.api.playlist.service.loader;
 import io.mopl.api.playlist.domain.PlaylistSubscription;
 import io.mopl.api.playlist.domain.PlaylistSubscriptionRepository;
 import io.mopl.redis.constants.RedisKeyPrefix;
+import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -40,12 +41,18 @@ public class PlaylistSubscriptionLoader {
         RedisSerializer<String> serializer =
             (RedisSerializer<String>) redisTemplate.getStringSerializer();
         byte[] keyBytes = serializer.serialize(key);
+        if (keyBytes == null) {
+          throw new IllegalStateException("Failed to serialize Redis key");
+        }
         List<Object> rawResults =
             redisTemplate.executePipelined(
                 (RedisCallback<Object>)
                     connection -> {
                       for (UUID playlistId : playlistIds) {
                         byte[] valueBytes = serializer.serialize(playlistId.toString());
+                        if (valueBytes == null) {
+                          continue;
+                        }
                         connection.sIsMember(keyBytes, valueBytes);
                       }
                       return null;
@@ -64,13 +71,31 @@ public class PlaylistSubscriptionLoader {
       // fallback to DB query below
     }
 
-    // 캐시가 없으면 현재 페이지의 playlistIds만 DB에서 조회
-    List<PlaylistSubscription> subs =
-        subscriptionRepository.findByIdUserIdAndIdPlaylistIdIn(me, playlistIds);
-    Set<UUID> subscribedIds = new HashSet<>();
-    for (PlaylistSubscription sub : subs) {
-      subscribedIds.add(sub.getId().getPlaylistId());
+    // 캐시가 없으면 사용자가 구독한 전체 플레이리스트를 DB에서 조회
+    List<PlaylistSubscription> allSubs = subscriptionRepository.findByIdUserId(me);
+    Set<UUID> allSubscribedIds = new HashSet<>();
+    for (PlaylistSubscription sub : allSubs) {
+      allSubscribedIds.add(sub.getId().getPlaylistId());
     }
-    return subscribedIds;
+
+    // 전체 구독 목록을 Redis에 저장
+    if (!allSubscribedIds.isEmpty()) {
+      try {
+        String[] values = allSubscribedIds.stream().map(UUID::toString).toArray(String[]::new);
+        redisTemplate.opsForSet().add(key, values);
+        redisTemplate.expire(key, Duration.ofHours(6));
+      } catch (Exception e) {
+        log.warn("Redis 캐시 저장 실패 key={} error={}", key, e.getMessage());
+      }
+    }
+
+    // 요청한 playlistIds 중 구독된 것만 반환
+    for (UUID playlistId : playlistIds) {
+      if (allSubscribedIds.contains(playlistId)) {
+        result.add(playlistId);
+      }
+    }
+
+    return result;
   }
 }

--- a/mopl-api/src/main/java/io/mopl/api/playlist/service/loader/PlaylistSubscriptionLoader.java
+++ b/mopl-api/src/main/java/io/mopl/api/playlist/service/loader/PlaylistSubscriptionLoader.java
@@ -71,14 +71,6 @@ public class PlaylistSubscriptionLoader {
     for (PlaylistSubscription sub : subs) {
       subscribedIds.add(sub.getId().getPlaylistId());
     }
-
-    // 요청된 playlistIds 중 구독된 것만 반환
-    for (UUID playlistId : playlistIds) {
-      if (subscribedIds.contains(playlistId)) {
-        result.add(playlistId);
-      }
-    }
-
-    return result;
+    return subscribedIds;
   }
 }

--- a/mopl-api/src/main/java/io/mopl/api/user/domain/UserRepository.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/domain/UserRepository.java
@@ -24,4 +24,7 @@ public interface UserRepository extends JpaRepository<User, UUID>, UserRepositor
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @Query("SELECT u FROM User u WHERE u.id = :id")
   Optional<User> findByIdWithLock(@Param("id") UUID id);
+
+  @Query("SELECT u.name FROM User u WHERE u.id = :userId")
+  Optional<String> findNameById(@Param("userId") UUID userId);
 }

--- a/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
@@ -100,11 +100,9 @@ public class UserService {
 
   @Transactional(readOnly = true)
   public String getUserName(UUID userId) {
-    User user =
-        userRepository
-            .findById(userId)
-            .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
-    return user.getName();
+    return userRepository
+        .findNameById(userId)
+        .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
   }
 
   @Transactional(readOnly = true)

--- a/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
@@ -98,6 +98,11 @@ public class UserService {
     return UserSummary.from(user, profileImageUrl);
   }
 
+  @Transactional(readOnly = true)
+  public boolean existsById(UUID userId) {
+    return userRepository.existsById(userId);
+  }
+
   /** 비밀번호 변경 */
   @Transactional
   public void changePassword(UUID userId, ChangePasswordRequest request) {

--- a/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
+++ b/mopl-api/src/main/java/io/mopl/api/user/service/UserService.java
@@ -99,6 +99,15 @@ public class UserService {
   }
 
   @Transactional(readOnly = true)
+  public String getUserName(UUID userId) {
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+    return user.getName();
+  }
+
+  @Transactional(readOnly = true)
   public boolean existsById(UUID userId) {
     return userRepository.existsById(userId);
   }

--- a/mopl-infrastructure/redis/src/main/java/io/mopl/redis/constants/RedisKeyPrefix.java
+++ b/mopl-infrastructure/redis/src/main/java/io/mopl/redis/constants/RedisKeyPrefix.java
@@ -38,6 +38,8 @@ public final class RedisKeyPrefix {
   /** 사용자 구독 플레이리스트 Set: playlist:subs:user:{userId} */
   public static final String PLAYLIST_SUBS_BY_USER = "playlist:subs:user:";
 
+  public static final String NOTIFICATION_UNREAD_COUNT = "notification:unread-count:";
+
   /** 인스턴스화 방지 */
   private RedisKeyPrefix() {
     throw new AssertionError("Cannot instantiate constants class");

--- a/mopl-infrastructure/redis/src/main/java/io/mopl/redis/constants/RedisKeyPrefix.java
+++ b/mopl-infrastructure/redis/src/main/java/io/mopl/redis/constants/RedisKeyPrefix.java
@@ -38,7 +38,13 @@ public final class RedisKeyPrefix {
   /** 사용자 구독 플레이리스트 Set: playlist:subs:user:{userId} */
   public static final String PLAYLIST_SUBS_BY_USER = "playlist:subs:user:";
 
+  // ===== 알림 (notification:) =====
+
+  /** 미읽음 알림 카운트: notification:unread-count:{userId} */
   public static final String NOTIFICATION_UNREAD_COUNT = "notification:unread-count:";
+
+  /** 미읽음 카운트 중복 방지 키: notification:unread-dedup:{notificationId} */
+  public static final String NOTIFICATION_UNREAD_DEDUP = "notification:unread-dedup:";
 
   /** 인스턴스화 방지 */
   private RedisKeyPrefix() {

--- a/mopl-infrastructure/redis/src/main/java/io/mopl/redis/constants/RedisKeyPrefix.java
+++ b/mopl-infrastructure/redis/src/main/java/io/mopl/redis/constants/RedisKeyPrefix.java
@@ -35,8 +35,10 @@ public final class RedisKeyPrefix {
   /** 플레이리스트 콘텐츠 캐시: playlist:contents:{playlistId} */
   public static final String PLAYLIST_CONTENTS = "playlist:contents:";
 
+  /** 플레이리스트 썸네일 콘텐츠 캐시: playlist:thumbnail-content:{playlistId} */
   public static final String PLAYLIST_THUMBNAIL_CONTENT = "playlist:thumbnail-content:";
 
+  /** 플레이리스트 총 개수 캐시: playlist:count:{filterHash} */
   public static final String PLAYLIST_COUNT = "playlist:count:";
 
   /** 사용자 구독 플레이리스트 Set: playlist:subs:user:{userId} */

--- a/mopl-infrastructure/redis/src/main/java/io/mopl/redis/constants/RedisKeyPrefix.java
+++ b/mopl-infrastructure/redis/src/main/java/io/mopl/redis/constants/RedisKeyPrefix.java
@@ -35,6 +35,8 @@ public final class RedisKeyPrefix {
   /** 플레이리스트 콘텐츠 캐시: playlist:contents:{playlistId} */
   public static final String PLAYLIST_CONTENTS = "playlist:contents:";
 
+  public static final String PLAYLIST_THUMBNAIL_CONTENT = "playlist:thumbnail-content:";
+
   /** 사용자 구독 플레이리스트 Set: playlist:subs:user:{userId} */
   public static final String PLAYLIST_SUBS_BY_USER = "playlist:subs:user:";
 

--- a/mopl-infrastructure/redis/src/main/java/io/mopl/redis/constants/RedisKeyPrefix.java
+++ b/mopl-infrastructure/redis/src/main/java/io/mopl/redis/constants/RedisKeyPrefix.java
@@ -37,6 +37,8 @@ public final class RedisKeyPrefix {
 
   public static final String PLAYLIST_THUMBNAIL_CONTENT = "playlist:thumbnail-content:";
 
+  public static final String PLAYLIST_COUNT = "playlist:count:";
+
   /** 사용자 구독 플레이리스트 Set: playlist:subs:user:{userId} */
   public static final String PLAYLIST_SUBS_BY_USER = "playlist:subs:user:";
 

--- a/mopl-socket/src/main/java/io/mopl/socket/SocketApplication.java
+++ b/mopl-socket/src/main/java/io/mopl/socket/SocketApplication.java
@@ -1,8 +1,11 @@
 package io.mopl.socket;
 
+import io.mopl.redis.config.RedisConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Import;
 
+@Import(RedisConfig.class)
 @SpringBootApplication
 public class SocketApplication {
   public static void main(String[] args) {

--- a/mopl-socket/src/main/java/io/mopl/socket/notification/NotificationEventListener.java
+++ b/mopl-socket/src/main/java/io/mopl/socket/notification/NotificationEventListener.java
@@ -22,6 +22,7 @@ import org.springframework.util.StringUtils;
 public class NotificationEventListener {
 
   private static final Duration UNREAD_COUNT_TTL = Duration.ofHours(1);
+  private static final Duration UNREAD_DEDUP_TTL = Duration.ofDays(1);
 
   private final SseService sseService;
   private final DirectMessageSubscriptionRegistry dmSubscriptionRegistry;
@@ -35,7 +36,7 @@ public class NotificationEventListener {
           "spring.json.value.default.type=io.mopl.core.event.notification.NotificationCreatedEvent")
   public void handleCreatedEvent(NotificationCreatedEvent event) {
     try {
-      incrementUnreadCount(event.receiverId());
+      incrementUnreadCount(event.receiverId(), event.notificationId());
       log.info("알림 생성 이벤트 수신: notificationId={}", event.notificationId());
 
       if (event.type() != null
@@ -81,11 +82,17 @@ public class NotificationEventListener {
     }
   }
 
-  private void incrementUnreadCount(String receiverId) {
-    if (!StringUtils.hasText(receiverId)) {
+  private void incrementUnreadCount(String receiverId, String notificationId) {
+    if (!StringUtils.hasText(receiverId) || !StringUtils.hasText(notificationId)) {
       return;
     }
     try {
+      String dedupKey = RedisKeyPrefix.NOTIFICATION_UNREAD_DEDUP + notificationId;
+      Boolean first = redisTemplate.opsForValue().setIfAbsent(dedupKey, "1", UNREAD_DEDUP_TTL);
+      if (first == null || !first) {
+        return;
+      }
+
       String key = RedisKeyPrefix.NOTIFICATION_UNREAD_COUNT + receiverId;
       Long value = redisTemplate.opsForValue().increment(key);
       if (value != null && value == 1L) {

--- a/mopl-socket/src/main/java/io/mopl/socket/notification/NotificationEventListener.java
+++ b/mopl-socket/src/main/java/io/mopl/socket/notification/NotificationEventListener.java
@@ -7,6 +7,7 @@ import io.mopl.redis.constants.RedisKeyPrefix;
 import io.mopl.socket.dm.DirectMessageSubscriptionRegistry;
 import io.mopl.socket.notification.dto.NotificationDto;
 import io.mopl.socket.sse.SseService;
+import java.time.Duration;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,6 +20,8 @@ import org.springframework.util.StringUtils;
 @Component
 @RequiredArgsConstructor
 public class NotificationEventListener {
+
+  private static final Duration UNREAD_COUNT_TTL = Duration.ofHours(1);
 
   private final SseService sseService;
   private final DirectMessageSubscriptionRegistry dmSubscriptionRegistry;
@@ -83,9 +86,13 @@ public class NotificationEventListener {
       return;
     }
     try {
-      redisTemplate.opsForValue().increment(RedisKeyPrefix.NOTIFICATION_UNREAD_COUNT + receiverId);
+      String key = RedisKeyPrefix.NOTIFICATION_UNREAD_COUNT + receiverId;
+      Long value = redisTemplate.opsForValue().increment(key);
+      if (value != null && value == 1L) {
+        redisTemplate.expire(key, UNREAD_COUNT_TTL);
+      }
     } catch (Exception e) {
-      log.warn("?좎쓽 誘몄씫??알림 카운트 증가 실패: receiverId={}", receiverId, e);
+      log.warn("미읽음 알림 카운트 증가 실패: receiverId={}", receiverId, e);
     }
   }
 }

--- a/mopl-socket/src/main/java/io/mopl/socket/notification/NotificationEventListener.java
+++ b/mopl-socket/src/main/java/io/mopl/socket/notification/NotificationEventListener.java
@@ -3,12 +3,14 @@ package io.mopl.socket.notification;
 import io.mopl.core.event.notification.NotificationCreatedEvent;
 import io.mopl.core.event.notification.NotificationType;
 import io.mopl.core.kafka.KafkaTopics;
+import io.mopl.redis.constants.RedisKeyPrefix;
 import io.mopl.socket.dm.DirectMessageSubscriptionRegistry;
 import io.mopl.socket.notification.dto.NotificationDto;
 import io.mopl.socket.sse.SseService;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -20,6 +22,7 @@ public class NotificationEventListener {
 
   private final SseService sseService;
   private final DirectMessageSubscriptionRegistry dmSubscriptionRegistry;
+  private final RedisTemplate<String, String> redisTemplate;
 
   // 알림 생성 이벤트를 수신해 SSE로 전송한다.
   @KafkaListener(
@@ -29,6 +32,7 @@ public class NotificationEventListener {
           "spring.json.value.default.type=io.mopl.core.event.notification.NotificationCreatedEvent")
   public void handleCreatedEvent(NotificationCreatedEvent event) {
     try {
+      incrementUnreadCount(event.receiverId());
       log.info("알림 생성 이벤트 수신: notificationId={}", event.notificationId());
 
       if (event.type() != null
@@ -71,6 +75,17 @@ public class NotificationEventListener {
     } catch (RuntimeException e) {
       log.warn("알림 이벤트 UUID 형식 오류로 무시: {}={}", fieldName, value);
       return null;
+    }
+  }
+
+  private void incrementUnreadCount(String receiverId) {
+    if (!StringUtils.hasText(receiverId)) {
+      return;
+    }
+    try {
+      redisTemplate.opsForValue().increment(RedisKeyPrefix.NOTIFICATION_UNREAD_COUNT + receiverId);
+    } catch (Exception e) {
+      log.warn("?좎쓽 誘몄씫??알림 카운트 증가 실패: receiverId={}", receiverId, e);
     }
   }
 }

--- a/mopl-worker/src/main/java/io/mopl/worker/notification/NotificationListenerSupport.java
+++ b/mopl-worker/src/main/java/io/mopl/worker/notification/NotificationListenerSupport.java
@@ -1,6 +1,10 @@
 package io.mopl.worker.notification;
 
 import io.mopl.core.db.DbConstraintNames;
+import io.mopl.worker.notification.domain.Notification;
+import io.mopl.worker.notification.domain.NotificationRepository;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -34,5 +38,36 @@ public final class NotificationListenerSupport {
       log.error("UUID 형식이 올바르지 않습니다: {} (eventId={})", fieldName, eventId, e);
       throw e;
     }
+  }
+
+  static void saveAndPublishBatch(
+      Logger log,
+      List<Notification> notifications,
+      String eventId,
+      NotificationRepository notificationRepository,
+      NotificationEventPublisher notificationEventPublisher) {
+    if (notifications.isEmpty()) {
+      return;
+    }
+
+    try {
+      List<Notification> saved = notificationRepository.saveAll(notifications);
+      saved.forEach(notificationEventPublisher::publish);
+    } catch (DataIntegrityViolationException ex) {
+      for (Notification notification : notifications) {
+        try {
+          Notification saved = notificationRepository.save(notification);
+          notificationEventPublisher.publish(saved);
+        } catch (DataIntegrityViolationException inner) {
+          NotificationListenerSupport.handleDataIntegrityViolation(
+              log, inner, eventId + ":" + notification.getReceiverId());
+        }
+      }
+    }
+  }
+
+  static UUID toPerReceiverEventId(String eventId, UUID receiverId) {
+    String source = eventId + ":" + receiverId;
+    return UUID.nameUUIDFromBytes(source.getBytes(StandardCharsets.UTF_8));
   }
 }

--- a/mopl-worker/src/main/java/io/mopl/worker/notification/NotificationRecipientQuery.java
+++ b/mopl-worker/src/main/java/io/mopl/worker/notification/NotificationRecipientQuery.java
@@ -1,5 +1,7 @@
 package io.mopl.worker.notification;
 
+import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -16,24 +18,70 @@ public class NotificationRecipientQuery {
 
   private final JdbcTemplate jdbcTemplate;
 
-  // 팔로우/구독 알림 수신자 목록을 DB에서 조회한다.
-  // TODO: 대량 수신자 대비 배치/페이지네이션 처리 검토
-  public List<UUID> findFollowerIds(UUID followeeId) {
-    List<String> rows =
-        jdbcTemplate.queryForList(
-            "SELECT follower_id FROM follows WHERE followee_id = ? LIMIT 10000",
-            String.class,
-            followeeId.toString());
-    return toUuids(rows, "follower_id");
+  // 팔로워 알림 수신자를 커서 기반으로 조회한다.
+  public RecipientPage findFollowerIdsPage(
+      UUID followeeId, Instant cursorCreatedAt, String cursorId, int limit) {
+    StringBuilder sql =
+        new StringBuilder(
+            "SELECT follower_id AS receiver_id, created_at, id AS cursor_id "
+                + "FROM follows WHERE followee_id = ?");
+    List<Object> params = new ArrayList<>();
+    params.add(followeeId.toString());
+
+    if (cursorCreatedAt != null && cursorId != null) {
+      sql.append(" AND (created_at > ? OR (created_at = ? AND id > ?))");
+      params.add(Timestamp.from(cursorCreatedAt));
+      params.add(Timestamp.from(cursorCreatedAt));
+      params.add(cursorId);
+    }
+
+    sql.append(" ORDER BY created_at ASC, id ASC LIMIT ?");
+    params.add(limit + 1);
+
+    List<RecipientRow> rows =
+        jdbcTemplate.query(
+            sql.toString(),
+            (rs, rowNum) ->
+                new RecipientRow(
+                    rs.getString("receiver_id"),
+                    toInstant(rs.getTimestamp("created_at")),
+                    rs.getString("cursor_id")),
+            params.toArray());
+
+    return toRecipientPage(rows, limit, "follower_id");
   }
 
-  public List<UUID> findSubscriberIds(UUID playlistId) {
-    List<String> rows =
-        jdbcTemplate.queryForList(
-            "SELECT user_id FROM playlist_subscriptions WHERE playlist_id = ?",
-            String.class,
-            playlistId.toString());
-    return toUuids(rows, "user_id");
+  // 플레이리스트 구독자 알림 수신자를 커서 기반으로 조회한다.
+  public RecipientPage findSubscriberIdsPage(
+      UUID playlistId, Instant cursorCreatedAt, String cursorUserId, int limit) {
+    StringBuilder sql =
+        new StringBuilder(
+            "SELECT user_id AS receiver_id, created_at, user_id AS cursor_id "
+                + "FROM playlist_subscriptions WHERE playlist_id = ?");
+    List<Object> params = new ArrayList<>();
+    params.add(playlistId.toString());
+
+    if (cursorCreatedAt != null && cursorUserId != null) {
+      sql.append(" AND (created_at > ? OR (created_at = ? AND user_id > ?))");
+      params.add(Timestamp.from(cursorCreatedAt));
+      params.add(Timestamp.from(cursorCreatedAt));
+      params.add(cursorUserId);
+    }
+
+    sql.append(" ORDER BY created_at ASC, user_id ASC LIMIT ?");
+    params.add(limit + 1);
+
+    List<RecipientRow> rows =
+        jdbcTemplate.query(
+            sql.toString(),
+            (rs, rowNum) ->
+                new RecipientRow(
+                    rs.getString("receiver_id"),
+                    toInstant(rs.getTimestamp("created_at")),
+                    rs.getString("cursor_id")),
+            params.toArray());
+
+    return toRecipientPage(rows, limit, "user_id");
   }
 
   // 시청 알림 메시지에 사용할 콘텐츠 제목을 조회한다.
@@ -47,20 +95,38 @@ public class NotificationRecipientQuery {
     }
   }
 
-  private List<UUID> toUuids(List<String> rows, String columnName) {
-    List<UUID> results = new ArrayList<>(rows.size());
+  private RecipientPage toRecipientPage(List<RecipientRow> rows, int limit, String columnName) {
+    if (rows.isEmpty()) {
+      return new RecipientPage(List.of(), null, null, false);
+    }
+
+    boolean hasNext = rows.size() > limit;
+    List<RecipientRow> slice = hasNext ? rows.subList(0, limit) : rows;
+
+    List<UUID> results = new ArrayList<>(slice.size());
     int invalidCount = 0;
-    for (String value : rows) {
+    for (RecipientRow row : slice) {
       try {
-        results.add(UUID.fromString(value));
+        results.add(UUID.fromString(row.receiverId()));
       } catch (IllegalArgumentException e) {
-        log.warn("UUID 형식이 올바르지 않습니다: {}={}", columnName, value);
+        log.warn("UUID 형식이 올바르지 않습니다: {}={}", columnName, row.receiverId());
         invalidCount++;
       }
     }
     if (invalidCount > 0) {
-      log.error("총 {}개의 잘못된 UUID가 필터링되었습니다 (column={})", invalidCount, columnName);
+      log.error("총 {}개의 잘못된 UUID가 포함되어 있습니다 (column={})", invalidCount, columnName);
     }
-    return results;
+
+    RecipientRow last = slice.get(slice.size() - 1);
+    return new RecipientPage(results, last.createdAt(), last.cursorId(), hasNext);
   }
+
+  private Instant toInstant(Timestamp timestamp) {
+    return timestamp == null ? null : timestamp.toInstant();
+  }
+
+  private record RecipientRow(String receiverId, Instant createdAt, String cursorId) {}
+
+  public record RecipientPage(
+      List<UUID> receiverIds, Instant nextCreatedAt, String nextCursorId, boolean hasNext) {}
 }

--- a/mopl-worker/src/main/java/io/mopl/worker/notification/PlaylistNotificationListener.java
+++ b/mopl-worker/src/main/java/io/mopl/worker/notification/PlaylistNotificationListener.java
@@ -8,6 +8,7 @@ import io.mopl.worker.notification.domain.Notification;
 import io.mopl.worker.notification.domain.NotificationLevel;
 import io.mopl.worker.notification.domain.NotificationRepository;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
@@ -22,6 +23,8 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class PlaylistNotificationListener {
+
+  private static final int BATCH_SIZE = 500;
 
   private final NotificationRepository notificationRepository;
   private final NotificationRecipientQuery recipientQuery;
@@ -44,7 +47,7 @@ public class PlaylistNotificationListener {
           messageSource.getMessage(
               "notification.playlist.subscribed.title",
               new Object[] {event.subscriberName()},
-              "새 구독자: " + event.subscriberName(),
+              event.subscriberName() + "님이 플레이리스트를 구독했습니다.",
               Locale.KOREAN);
 
       Notification notification =
@@ -60,7 +63,7 @@ public class PlaylistNotificationListener {
     } catch (DataIntegrityViolationException e) {
       NotificationListenerSupport.handleDataIntegrityViolation(log, e, event.eventId());
     } catch (IllegalArgumentException e) {
-      // UUID 파싱 오류는 parseUuid에서 로그 처리.
+      // UUID 파싱 오류는 parseUuid에서 로그 처리한다.
     }
   }
 
@@ -79,31 +82,30 @@ public class PlaylistNotificationListener {
           messageSource.getMessage(
               "notification.playlist.content-added.title",
               null,
-              "플레이리스트에 새 콘텐츠가 추가되었습니다.",
+              "플레이리스트에 콘텐츠가 추가되었습니다.",
               Locale.KOREAN);
 
       List<UUID> receiverIds = recipientQuery.findSubscriberIds(playlistIdUuid);
-      for (UUID receiverId : receiverIds) {
-        try {
+      for (int start = 0; start < receiverIds.size(); start += BATCH_SIZE) {
+        List<UUID> batch =
+            receiverIds.subList(start, Math.min(start + BATCH_SIZE, receiverIds.size()));
+        List<Notification> notifications = new ArrayList<>(batch.size());
+        for (UUID receiverId : batch) {
           // 수신자별로 event_id를 분리해 중복 충돌을 방지한다.
           UUID eventIdUuid = toPerReceiverEventId(event.eventId(), receiverId);
-          Notification notification =
+          notifications.add(
               Notification.builder()
                   .eventId(eventIdUuid)
                   .receiverId(receiverId)
                   .title(title)
                   .content("")
                   .level(NotificationLevel.INFO)
-                  .build();
-          Notification saved = notificationRepository.save(notification);
-          notificationEventPublisher.publish(saved);
-        } catch (DataIntegrityViolationException ex) {
-          NotificationListenerSupport.handleDataIntegrityViolation(
-              log, ex, event.eventId() + ":" + receiverId);
+                  .build());
         }
+        saveAndPublishBatch(notifications, event.eventId());
       }
     } catch (IllegalArgumentException e) {
-      // UUID 파싱 오류는 parseUuid에서 로그 처리.
+      // UUID 파싱 오류는 parseUuid에서 로그 처리한다.
     }
   }
 
@@ -121,31 +123,51 @@ public class PlaylistNotificationListener {
           messageSource.getMessage(
               "notification.playlist.created.title",
               new Object[] {event.ownerName()},
-              "새 플레이리스트가 생성되었습니다. 작성자: " + event.ownerName(),
+              event.ownerName() + "님이 새 플레이리스트를 만들었어요.",
               Locale.KOREAN);
 
       List<UUID> receiverIds = recipientQuery.findFollowerIds(ownerIdUuid);
-      for (UUID receiverId : receiverIds) {
-        try {
+      for (int start = 0; start < receiverIds.size(); start += BATCH_SIZE) {
+        List<UUID> batch =
+            receiverIds.subList(start, Math.min(start + BATCH_SIZE, receiverIds.size()));
+        List<Notification> notifications = new ArrayList<>(batch.size());
+        for (UUID receiverId : batch) {
           // 수신자별로 event_id를 분리해 중복 충돌을 방지한다.
           UUID eventIdUuid = toPerReceiverEventId(event.eventId(), receiverId);
-          Notification notification =
+          notifications.add(
               Notification.builder()
                   .eventId(eventIdUuid)
                   .receiverId(receiverId)
                   .title(title)
                   .content("")
                   .level(NotificationLevel.INFO)
-                  .build();
-          Notification saved = notificationRepository.save(notification);
-          notificationEventPublisher.publish(saved);
-        } catch (DataIntegrityViolationException ex) {
-          NotificationListenerSupport.handleDataIntegrityViolation(
-              log, ex, event.eventId() + ":" + receiverId);
+                  .build());
         }
+        saveAndPublishBatch(notifications, event.eventId());
       }
     } catch (IllegalArgumentException e) {
-      // UUID 파싱 오류는 parseUuid에서 로그 처리.
+      // UUID 파싱 오류는 parseUuid에서 로그 처리한다.
+    }
+  }
+
+  private void saveAndPublishBatch(List<Notification> notifications, String eventId) {
+    if (notifications.isEmpty()) {
+      return;
+    }
+
+    try {
+      List<Notification> saved = notificationRepository.saveAll(notifications);
+      saved.forEach(notificationEventPublisher::publish);
+    } catch (DataIntegrityViolationException ex) {
+      for (Notification notification : notifications) {
+        try {
+          Notification saved = notificationRepository.save(notification);
+          notificationEventPublisher.publish(saved);
+        } catch (DataIntegrityViolationException inner) {
+          NotificationListenerSupport.handleDataIntegrityViolation(
+              log, inner, eventId + ":" + notification.getReceiverId());
+        }
+      }
     }
   }
 

--- a/mopl-worker/src/main/java/io/mopl/worker/notification/PlaylistNotificationListener.java
+++ b/mopl-worker/src/main/java/io/mopl/worker/notification/PlaylistNotificationListener.java
@@ -8,6 +8,7 @@ import io.mopl.worker.notification.domain.Notification;
 import io.mopl.worker.notification.domain.NotificationLevel;
 import io.mopl.worker.notification.domain.NotificationRepository;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -85,24 +86,36 @@ public class PlaylistNotificationListener {
               "플레이리스트에 콘텐츠가 추가되었습니다.",
               Locale.KOREAN);
 
-      List<UUID> receiverIds = recipientQuery.findSubscriberIds(playlistIdUuid);
-      for (int start = 0; start < receiverIds.size(); start += BATCH_SIZE) {
-        List<UUID> batch =
-            receiverIds.subList(start, Math.min(start + BATCH_SIZE, receiverIds.size()));
-        List<Notification> notifications = new ArrayList<>(batch.size());
-        for (UUID receiverId : batch) {
-          // 수신자별로 event_id를 분리해 중복 충돌을 방지한다.
-          UUID eventIdUuid = toPerReceiverEventId(event.eventId(), receiverId);
-          notifications.add(
-              Notification.builder()
-                  .eventId(eventIdUuid)
-                  .receiverId(receiverId)
-                  .title(title)
-                  .content("")
-                  .level(NotificationLevel.INFO)
-                  .build());
+      Instant cursorCreatedAt = null;
+      String cursorUserId = null;
+
+      while (true) {
+        NotificationRecipientQuery.RecipientPage page =
+            recipientQuery.findSubscriberIdsPage(
+                playlistIdUuid, cursorCreatedAt, cursorUserId, BATCH_SIZE);
+
+        if (!page.receiverIds().isEmpty()) {
+          List<Notification> notifications = new ArrayList<>(page.receiverIds().size());
+          for (UUID receiverId : page.receiverIds()) {
+            // 수신자별로 event_id를 분리해 중복 충돌을 방지한다.
+            UUID eventIdUuid = toPerReceiverEventId(event.eventId(), receiverId);
+            notifications.add(
+                Notification.builder()
+                    .eventId(eventIdUuid)
+                    .receiverId(receiverId)
+                    .title(title)
+                    .content("")
+                    .level(NotificationLevel.INFO)
+                    .build());
+          }
+          saveAndPublishBatch(notifications, event.eventId());
         }
-        saveAndPublishBatch(notifications, event.eventId());
+
+        if (!page.hasNext() || page.nextCreatedAt() == null || page.nextCursorId() == null) {
+          break;
+        }
+        cursorCreatedAt = page.nextCreatedAt();
+        cursorUserId = page.nextCursorId();
       }
     } catch (IllegalArgumentException e) {
       // UUID 파싱 오류는 parseUuid에서 로그 처리한다.
@@ -126,24 +139,35 @@ public class PlaylistNotificationListener {
               event.ownerName() + "님이 새 플레이리스트를 만들었어요.",
               Locale.KOREAN);
 
-      List<UUID> receiverIds = recipientQuery.findFollowerIds(ownerIdUuid);
-      for (int start = 0; start < receiverIds.size(); start += BATCH_SIZE) {
-        List<UUID> batch =
-            receiverIds.subList(start, Math.min(start + BATCH_SIZE, receiverIds.size()));
-        List<Notification> notifications = new ArrayList<>(batch.size());
-        for (UUID receiverId : batch) {
-          // 수신자별로 event_id를 분리해 중복 충돌을 방지한다.
-          UUID eventIdUuid = toPerReceiverEventId(event.eventId(), receiverId);
-          notifications.add(
-              Notification.builder()
-                  .eventId(eventIdUuid)
-                  .receiverId(receiverId)
-                  .title(title)
-                  .content("")
-                  .level(NotificationLevel.INFO)
-                  .build());
+      Instant cursorCreatedAt = null;
+      String cursorId = null;
+
+      while (true) {
+        NotificationRecipientQuery.RecipientPage page =
+            recipientQuery.findFollowerIdsPage(ownerIdUuid, cursorCreatedAt, cursorId, BATCH_SIZE);
+
+        if (!page.receiverIds().isEmpty()) {
+          List<Notification> notifications = new ArrayList<>(page.receiverIds().size());
+          for (UUID receiverId : page.receiverIds()) {
+            // 수신자별로 event_id를 분리해 중복 충돌을 방지한다.
+            UUID eventIdUuid = toPerReceiverEventId(event.eventId(), receiverId);
+            notifications.add(
+                Notification.builder()
+                    .eventId(eventIdUuid)
+                    .receiverId(receiverId)
+                    .title(title)
+                    .content("")
+                    .level(NotificationLevel.INFO)
+                    .build());
+          }
+          saveAndPublishBatch(notifications, event.eventId());
         }
-        saveAndPublishBatch(notifications, event.eventId());
+
+        if (!page.hasNext() || page.nextCreatedAt() == null || page.nextCursorId() == null) {
+          break;
+        }
+        cursorCreatedAt = page.nextCreatedAt();
+        cursorId = page.nextCursorId();
       }
     } catch (IllegalArgumentException e) {
       // UUID 파싱 오류는 parseUuid에서 로그 처리한다.

--- a/mopl-worker/src/main/java/io/mopl/worker/notification/PlaylistNotificationListener.java
+++ b/mopl-worker/src/main/java/io/mopl/worker/notification/PlaylistNotificationListener.java
@@ -7,7 +7,6 @@ import io.mopl.core.kafka.KafkaTopics;
 import io.mopl.worker.notification.domain.Notification;
 import io.mopl.worker.notification.domain.NotificationLevel;
 import io.mopl.worker.notification.domain.NotificationRepository;
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -98,7 +97,8 @@ public class PlaylistNotificationListener {
           List<Notification> notifications = new ArrayList<>(page.receiverIds().size());
           for (UUID receiverId : page.receiverIds()) {
             // 수신자별로 event_id를 분리해 중복 충돌을 방지한다.
-            UUID eventIdUuid = toPerReceiverEventId(event.eventId(), receiverId);
+            UUID eventIdUuid =
+                NotificationListenerSupport.toPerReceiverEventId(event.eventId(), receiverId);
             notifications.add(
                 Notification.builder()
                     .eventId(eventIdUuid)
@@ -108,7 +108,12 @@ public class PlaylistNotificationListener {
                     .level(NotificationLevel.INFO)
                     .build());
           }
-          saveAndPublishBatch(notifications, event.eventId());
+          NotificationListenerSupport.saveAndPublishBatch(
+              log,
+              notifications,
+              event.eventId(),
+              notificationRepository,
+              notificationEventPublisher);
         }
 
         if (!page.hasNext() || page.nextCreatedAt() == null || page.nextCursorId() == null) {
@@ -150,7 +155,8 @@ public class PlaylistNotificationListener {
           List<Notification> notifications = new ArrayList<>(page.receiverIds().size());
           for (UUID receiverId : page.receiverIds()) {
             // 수신자별로 event_id를 분리해 중복 충돌을 방지한다.
-            UUID eventIdUuid = toPerReceiverEventId(event.eventId(), receiverId);
+            UUID eventIdUuid =
+                NotificationListenerSupport.toPerReceiverEventId(event.eventId(), receiverId);
             notifications.add(
                 Notification.builder()
                     .eventId(eventIdUuid)
@@ -160,7 +166,12 @@ public class PlaylistNotificationListener {
                     .level(NotificationLevel.INFO)
                     .build());
           }
-          saveAndPublishBatch(notifications, event.eventId());
+          NotificationListenerSupport.saveAndPublishBatch(
+              log,
+              notifications,
+              event.eventId(),
+              notificationRepository,
+              notificationEventPublisher);
         }
 
         if (!page.hasNext() || page.nextCreatedAt() == null || page.nextCursorId() == null) {
@@ -172,31 +183,5 @@ public class PlaylistNotificationListener {
     } catch (IllegalArgumentException e) {
       // UUID 파싱 오류는 parseUuid에서 로그 처리한다.
     }
-  }
-
-  private void saveAndPublishBatch(List<Notification> notifications, String eventId) {
-    if (notifications.isEmpty()) {
-      return;
-    }
-
-    try {
-      List<Notification> saved = notificationRepository.saveAll(notifications);
-      saved.forEach(notificationEventPublisher::publish);
-    } catch (DataIntegrityViolationException ex) {
-      for (Notification notification : notifications) {
-        try {
-          Notification saved = notificationRepository.save(notification);
-          notificationEventPublisher.publish(saved);
-        } catch (DataIntegrityViolationException inner) {
-          NotificationListenerSupport.handleDataIntegrityViolation(
-              log, inner, eventId + ":" + notification.getReceiverId());
-        }
-      }
-    }
-  }
-
-  private UUID toPerReceiverEventId(String eventId, UUID receiverId) {
-    String source = eventId + ":" + receiverId;
-    return UUID.nameUUIDFromBytes(source.getBytes(StandardCharsets.UTF_8));
   }
 }

--- a/mopl-worker/src/main/java/io/mopl/worker/notification/WatchingSessionNotificationListener.java
+++ b/mopl-worker/src/main/java/io/mopl/worker/notification/WatchingSessionNotificationListener.java
@@ -5,7 +5,6 @@ import io.mopl.core.kafka.KafkaTopics;
 import io.mopl.worker.notification.domain.Notification;
 import io.mopl.worker.notification.domain.NotificationLevel;
 import io.mopl.worker.notification.domain.NotificationRepository;
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -14,7 +13,6 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.MessageSource;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
@@ -68,7 +66,8 @@ public class WatchingSessionNotificationListener {
           List<Notification> notifications = new ArrayList<>(page.receiverIds().size());
           for (UUID receiverId : page.receiverIds()) {
             // 수신자별로 event_id를 분리해 중복 충돌을 방지한다.
-            UUID eventIdUuid = toPerReceiverEventId(event.eventId(), receiverId);
+            UUID eventIdUuid =
+                NotificationListenerSupport.toPerReceiverEventId(event.eventId(), receiverId);
             notifications.add(
                 Notification.builder()
                     .eventId(eventIdUuid)
@@ -78,7 +77,12 @@ public class WatchingSessionNotificationListener {
                     .level(NotificationLevel.INFO)
                     .build());
           }
-          saveAndPublishBatch(notifications, event.eventId());
+          NotificationListenerSupport.saveAndPublishBatch(
+              log,
+              notifications,
+              event.eventId(),
+              notificationRepository,
+              notificationEventPublisher);
         }
 
         if (!page.hasNext() || page.nextCreatedAt() == null || page.nextCursorId() == null) {
@@ -88,33 +92,8 @@ public class WatchingSessionNotificationListener {
         cursorId = page.nextCursorId();
       }
     } catch (IllegalArgumentException e) {
-      // UUID 파싱 오류는 parseUuid에서 로그 처리한다.
-    }
-  }
-
-  private void saveAndPublishBatch(List<Notification> notifications, String eventId) {
-    if (notifications.isEmpty()) {
+      // UUID 파싱 오류는 parseUuid에서 로그 처리된다.
       return;
     }
-
-    try {
-      List<Notification> saved = notificationRepository.saveAll(notifications);
-      saved.forEach(notificationEventPublisher::publish);
-    } catch (DataIntegrityViolationException ex) {
-      for (Notification notification : notifications) {
-        try {
-          Notification saved = notificationRepository.save(notification);
-          notificationEventPublisher.publish(saved);
-        } catch (DataIntegrityViolationException inner) {
-          NotificationListenerSupport.handleDataIntegrityViolation(
-              log, inner, eventId + ":" + notification.getReceiverId());
-        }
-      }
-    }
-  }
-
-  private UUID toPerReceiverEventId(String eventId, UUID receiverId) {
-    String source = eventId + ":" + receiverId;
-    return UUID.nameUUIDFromBytes(source.getBytes(StandardCharsets.UTF_8));
   }
 }

--- a/mopl-worker/src/main/java/io/mopl/worker/notification/WatchingSessionNotificationListener.java
+++ b/mopl-worker/src/main/java/io/mopl/worker/notification/WatchingSessionNotificationListener.java
@@ -6,6 +6,7 @@ import io.mopl.worker.notification.domain.Notification;
 import io.mopl.worker.notification.domain.NotificationLevel;
 import io.mopl.worker.notification.domain.NotificationRepository;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
@@ -20,6 +21,8 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class WatchingSessionNotificationListener {
+
+  private static final int BATCH_SIZE = 500;
 
   private final NotificationRepository notificationRepository;
   private final NotificationRecipientQuery recipientQuery;
@@ -53,27 +56,47 @@ public class WatchingSessionNotificationListener {
               Locale.KOREAN);
 
       List<UUID> receiverIds = recipientQuery.findFollowerIds(watcherIdUuid);
-      for (UUID receiverId : receiverIds) {
-        try {
+      for (int start = 0; start < receiverIds.size(); start += BATCH_SIZE) {
+        List<UUID> batch =
+            receiverIds.subList(start, Math.min(start + BATCH_SIZE, receiverIds.size()));
+        List<Notification> notifications = new ArrayList<>(batch.size());
+        for (UUID receiverId : batch) {
           // 수신자별로 event_id를 분리해 중복 충돌을 방지한다.
           UUID eventIdUuid = toPerReceiverEventId(event.eventId(), receiverId);
-          Notification notification =
+          notifications.add(
               Notification.builder()
                   .eventId(eventIdUuid)
                   .receiverId(receiverId)
                   .title(title)
                   .content("")
                   .level(NotificationLevel.INFO)
-                  .build();
-          Notification saved = notificationRepository.save(notification);
-          notificationEventPublisher.publish(saved);
-        } catch (DataIntegrityViolationException ex) {
-          NotificationListenerSupport.handleDataIntegrityViolation(
-              log, ex, event.eventId() + ":" + receiverId);
+                  .build());
         }
+        saveAndPublishBatch(notifications, event.eventId());
       }
     } catch (IllegalArgumentException e) {
-      // UUID 파싱 오류는 parseUuid에서 로그 처리.
+      // UUID 파싱 오류는 parseUuid에서 로그 처리한다.
+    }
+  }
+
+  private void saveAndPublishBatch(List<Notification> notifications, String eventId) {
+    if (notifications.isEmpty()) {
+      return;
+    }
+
+    try {
+      List<Notification> saved = notificationRepository.saveAll(notifications);
+      saved.forEach(notificationEventPublisher::publish);
+    } catch (DataIntegrityViolationException ex) {
+      for (Notification notification : notifications) {
+        try {
+          Notification saved = notificationRepository.save(notification);
+          notificationEventPublisher.publish(saved);
+        } catch (DataIntegrityViolationException inner) {
+          NotificationListenerSupport.handleDataIntegrityViolation(
+              log, inner, eventId + ":" + notification.getReceiverId());
+        }
+      }
     }
   }
 

--- a/mopl-worker/src/main/java/io/mopl/worker/notification/WatchingSessionNotificationListener.java
+++ b/mopl-worker/src/main/java/io/mopl/worker/notification/WatchingSessionNotificationListener.java
@@ -6,6 +6,7 @@ import io.mopl.worker.notification.domain.Notification;
 import io.mopl.worker.notification.domain.NotificationLevel;
 import io.mopl.worker.notification.domain.NotificationRepository;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -55,24 +56,36 @@ public class WatchingSessionNotificationListener {
               event.watcherName() + "님이 " + contentTitle + " 시청을 시작했습니다.",
               Locale.KOREAN);
 
-      List<UUID> receiverIds = recipientQuery.findFollowerIds(watcherIdUuid);
-      for (int start = 0; start < receiverIds.size(); start += BATCH_SIZE) {
-        List<UUID> batch =
-            receiverIds.subList(start, Math.min(start + BATCH_SIZE, receiverIds.size()));
-        List<Notification> notifications = new ArrayList<>(batch.size());
-        for (UUID receiverId : batch) {
-          // 수신자별로 event_id를 분리해 중복 충돌을 방지한다.
-          UUID eventIdUuid = toPerReceiverEventId(event.eventId(), receiverId);
-          notifications.add(
-              Notification.builder()
-                  .eventId(eventIdUuid)
-                  .receiverId(receiverId)
-                  .title(title)
-                  .content("")
-                  .level(NotificationLevel.INFO)
-                  .build());
+      Instant cursorCreatedAt = null;
+      String cursorId = null;
+
+      while (true) {
+        NotificationRecipientQuery.RecipientPage page =
+            recipientQuery.findFollowerIdsPage(
+                watcherIdUuid, cursorCreatedAt, cursorId, BATCH_SIZE);
+
+        if (!page.receiverIds().isEmpty()) {
+          List<Notification> notifications = new ArrayList<>(page.receiverIds().size());
+          for (UUID receiverId : page.receiverIds()) {
+            // 수신자별로 event_id를 분리해 중복 충돌을 방지한다.
+            UUID eventIdUuid = toPerReceiverEventId(event.eventId(), receiverId);
+            notifications.add(
+                Notification.builder()
+                    .eventId(eventIdUuid)
+                    .receiverId(receiverId)
+                    .title(title)
+                    .content("")
+                    .level(NotificationLevel.INFO)
+                    .build());
+          }
+          saveAndPublishBatch(notifications, event.eventId());
         }
-        saveAndPublishBatch(notifications, event.eventId());
+
+        if (!page.hasNext() || page.nextCreatedAt() == null || page.nextCursorId() == null) {
+          break;
+        }
+        cursorCreatedAt = page.nextCreatedAt();
+        cursorId = page.nextCursorId();
       }
     } catch (IllegalArgumentException e) {
       // UUID 파싱 오류는 parseUuid에서 로그 처리한다.


### PR DESCRIPTION
## 📌 작업 개요
- 작업 내용: 팔로우/ 플레이리스트 / 알림 성능개선
- 관련 이슈: #이슈번호

## 🚀 주요 변경 사항
- 알림 저장 saveAll 청크 처리 
- 팔로워/구독자 조회를 커서 기반 페이지로 교체
- 커서 기반 조회/알림 목록 조회에 맞춘 복합 인덱스 추가
- 팔로우 생성 성능 개선
- 알림 미읽음 카운트 캐시를 Redis로 적용 +  TTL 추가
- findPlaylist()에서 단건 조회도 PlaylistOwnerLoader를 우선 사용하도록 적용
- 팔로우 알림 발행 시 프로필/프리사인 URL 생성 없이 이름만 조회 - 경량화 된 메서드 생성

## 🛠 DB 변경 사항
- 커서 기반 조회/알림 목록 조회에 맞춘 복합 인덱스 추가

## 🧪 테스트 결과 (필수)
<img width="493" height="538" alt="2" src="https://github.com/user-attachments/assets/7ec4b4d4-bc02-4e2e-b826-c9135dbb8a75" />
<img width="492" height="419" alt="성능 개선 후 알림 테스트 1" src="https://github.com/user-attachments/assets/fed41835-22e6-4d4c-a34c-0e7856004d65" />

- [x] **테스트 수행 완료**
- **테스트 시나리오:** 성능 개선 후 로컬로 기능을 한번 씩 해보며 알림이 제대로 오는지 전체적으로 확인하였습니다.
- **증빙자료:** (Postman 응답 결과 캡쳐본 첨부 또는 JSON 응답 복사)

## ✅ 체크리스트
- [x] 코드 컨벤션(Checkstyle/Spotless)을 준수했는가?
- [x] 빌드가 성공적으로 수행되는가? (`./gradlew build`)
- [x] 불필요한 주석이나 print문은 제거했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **성능 개선**
  * 복합 인덱스 추가로 조회 성능 향상
  * 플레이리스트 총계·썸네일·콘텐츠 Redis 캐시 도입으로 조회 속도 개선

* **새로운 기능**
  * 알림 전송의 일괄 배치 처리 및 커서 기반 수신자 페이징 도입
  * 실시간 소켓에 Redis 구성 추가로 알림 카운트 연동 강화
  * 알림 읽지않음 카운트 캐시(증감·중복 방지) 도입

* **안정성 개선**
  * 중복 삽입 복원 로직 및 캐시 오류에 대한 예외 처리 강화
  * 캐시 무효화 경로 통합으로 일관된 캐시 삭제 보장

* **API 변경**
  * 사용자 이름 조회 및 존재 확인용 읽기 전용 메서드 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->