### PR TITLE
refactor: 플레이리스트 캐시 조회를 문자열 파싱 방식으로 변경

### DIFF
--- a/mopl-api/src/main/java/io/mopl/api/playlist/service/PlaylistQueryService.java
+++ b/mopl-api/src/main/java/io/mopl/api/playlist/service/PlaylistQueryService.java
@@ -86,6 +86,9 @@ public class PlaylistQueryService {
       UUID playlistId = playlist.getId();
 
       UserSummary owner = ownerMap.get(playlist.getOwnerId());
+      if (owner == null) {
+        owner = userService.getUserSummary(playlist.getOwnerId());
+      }
       boolean subscribedByMe = subscribedPlaylistIds.contains(playlistId);
 
       List<ContentSummary> contents = contentsMap.get(playlistId);

--- a/mopl-api/src/main/java/io/mopl/api/playlist/service/loader/PlaylistContentLoader.java
+++ b/mopl-api/src/main/java/io/mopl/api/playlist/service/loader/PlaylistContentLoader.java
@@ -1,5 +1,7 @@
 package io.mopl.api.playlist.service.loader;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.querydsl.core.Tuple;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -28,7 +30,8 @@ import org.springframework.stereotype.Component;
 public class PlaylistContentLoader {
 
   private final JPAQueryFactory queryFactory;
-  private final RedisTemplate<String, Object> redisTemplateForObject;
+  private final RedisTemplate<String, String> redisTemplate;
+  private final ObjectMapper objectMapper;
 
   public Map<UUID, List<ContentSummary>> loadThumbnailContentsByPlaylistIds(
       List<UUID> playlistIds) {
@@ -40,9 +43,9 @@ public class PlaylistContentLoader {
     List<String> keys =
         playlistIdList.stream().map(id -> RedisKeyPrefix.PLAYLIST_THUMBNAIL_CONTENT + id).toList();
 
-    List<Object> cached;
+    List<String> cached;
     try {
-      cached = redisTemplateForObject.opsForValue().multiGet(keys);
+      cached = redisTemplate.opsForValue().multiGet(keys);
     } catch (Exception e) {
       log.warn("Redis 캐시 조회 실패 keyCount={} error={}", keys.size(), e.getMessage());
       cached = null;
@@ -58,20 +61,15 @@ public class PlaylistContentLoader {
     List<UUID> missIds = new ArrayList<>();
 
     for (int i = 0; i < playlistIdList.size(); i++) {
-      Object value = cached.get(i);
-      if (value instanceof List<?> list) {
-        if (list.isEmpty()) {
-          result.put(playlistIdList.get(i), List.of());
-        } else if (list.get(0) instanceof ContentSummary) {
-          @SuppressWarnings("unchecked")
-          List<ContentSummary> summaries = (List<ContentSummary>) list;
+      String value = cached.get(i);
+      if (value != null) {
+        List<ContentSummary> summaries = parseContentSummaries(value, keys.get(i));
+        if (summaries != null) {
           result.put(playlistIdList.get(i), summaries);
-        } else {
-          missIds.add(playlistIdList.get(i));
+          continue;
         }
-      } else {
-        missIds.add(playlistIdList.get(i));
       }
+      missIds.add(playlistIdList.get(i));
     }
 
     if (missIds.isEmpty()) {
@@ -214,9 +212,9 @@ public class PlaylistContentLoader {
         playlistIdList.stream().map(id -> RedisKeyPrefix.PLAYLIST_CONTENTS + id).toList();
 
     // 개별 조회로 역직렬화 문제 키만 제거
-    List<Object> cached;
+    List<String> cached;
     try {
-      cached = redisTemplateForObject.opsForValue().multiGet(keys);
+      cached = redisTemplate.opsForValue().multiGet(keys);
     } catch (Exception e) {
       log.warn("Redis 캐시 조회 실패 keyCount={} error={}", keys.size(), e.getMessage());
       cached = null;
@@ -233,20 +231,15 @@ public class PlaylistContentLoader {
     List<UUID> missIds = new ArrayList<>();
 
     for (int i = 0; i < playlistIdList.size(); i++) {
-      Object value = cached.get(i);
-      if (value instanceof List<?> list) {
-        if (list.isEmpty()) {
-          result.put(playlistIdList.get(i), List.of());
-        } else if (list.get(0) instanceof ContentSummary) {
-          @SuppressWarnings("unchecked")
-          List<ContentSummary> summaries = (List<ContentSummary>) list;
+      String value = cached.get(i);
+      if (value != null) {
+        List<ContentSummary> summaries = parseContentSummaries(value, keys.get(i));
+        if (summaries != null) {
           result.put(playlistIdList.get(i), summaries);
-        } else {
-          missIds.add(playlistIdList.get(i));
+          continue;
         }
-      } else {
-        missIds.add(playlistIdList.get(i));
       }
+      missIds.add(playlistIdList.get(i));
     }
 
     // 전부 캐시 hit이면 바로 반환
@@ -389,15 +382,25 @@ public class PlaylistContentLoader {
       Map<UUID, List<ContentSummary>> result, List<UUID> missIds, String keyPrefix) {
     for (UUID playlistId : missIds) {
       try {
-        redisTemplateForObject
-            .opsForValue()
-            .set(
-                keyPrefix + playlistId,
-                result.getOrDefault(playlistId, List.of()),
-                Duration.ofMinutes(30));
+        String json = objectMapper.writeValueAsString(result.getOrDefault(playlistId, List.of()));
+        redisTemplate.opsForValue().set(keyPrefix + playlistId, json, Duration.ofMinutes(30));
       } catch (Exception e) {
         log.debug("Redis 캐시 저장 실패 playlistId={} error={}", playlistId, e.getMessage());
       }
+    }
+  }
+
+  private List<ContentSummary> parseContentSummaries(String json, String key) {
+    try {
+      return objectMapper.readValue(json, new TypeReference<List<ContentSummary>>() {});
+    } catch (Exception e) {
+      log.warn("Redis 캐시 역직렬화 실패 key={} error={}", key, e.getMessage());
+      try {
+        redisTemplate.delete(key);
+      } catch (Exception ignored) {
+        // ignore cleanup failure
+      }
+      return null;
     }
   }
 

--- a/mopl-infrastructure/redis/src/main/java/io/mopl/redis/constants/RedisKeyPrefix.java
+++ b/mopl-infrastructure/redis/src/main/java/io/mopl/redis/constants/RedisKeyPrefix.java
@@ -33,10 +33,10 @@ public final class RedisKeyPrefix {
   public static final String USER_SUMMARY = "user:summary:";
 
   /** 플레이리스트 콘텐츠 캐시: playlist:contents:{playlistId} */
-  public static final String PLAYLIST_CONTENTS = "playlist:contents:v2:";
+  public static final String PLAYLIST_CONTENTS = "playlist:contents:v3:";
 
   /** 플레이리스트 썸네일 콘텐츠 캐시: playlist:thumbnail-content:{playlistId} */
-  public static final String PLAYLIST_THUMBNAIL_CONTENT = "playlist:thumbnail-content:v2:";
+  public static final String PLAYLIST_THUMBNAIL_CONTENT = "playlist:thumbnail-content:v3:";
 
   /** 플레이리스트 총 개수 캐시: playlist:count:{filterHash} */
   public static final String PLAYLIST_COUNT = "playlist:count:";


### PR DESCRIPTION
## 📌 작업 개요
- 작업 내용: 플레이리스트 캐시 조회를 문자열 파싱 방식으로 변경
- 관련 이슈: #이슈번호

## 🚀 주요 변경 사항
- 플레이리스트 캐시 조회를 문자열 파싱 방식으로 변경

## 🛠 DB 변경 사항

## 🧪 테스트 결과 (필수)

- [ ] **테스트 수행 완료**

## ✅ 체크리스트
- [x] 코드 컨벤션(Checkstyle/Spotless)을 준수했는가?
- [x] 빌드가 성공적으로 수행되는가? (`./gradlew build`)
- [x] 불필요한 주석이나 print문은 제거했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 플레이리스트 소유자 정보 로드 안정성을 개선했습니다.
  * 캐시 저장 방식을 최적화하여 데이터 조회 성능을 향상했습니다.
  * 캐시 무효화 시 자동 정리 메커니즘을 추가하여 데이터 일관성을 강화했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->