### PR TITLE
feat: SecurityConfig에서 GET 메서드의 refresh 허용 제거

### DIFF
--- a/mopl-api/src/main/java/io/mopl/api/common/config/SecurityConfig.java
+++ b/mopl-api/src/main/java/io/mopl/api/common/config/SecurityConfig.java
@@ -103,8 +103,6 @@ public class SecurityConfig {
 
                         String jsonResponse = objectMapper.writeValueAsString(errorResponse);
                         response.getWriter().write(jsonResponse);
-                      } else {
-                        response.sendRedirect("/login");
                       }
                     }))
         .authorizeHttpRequests(
@@ -131,6 +129,7 @@ public class SecurityConfig {
 
                     /* ========== SPA 프론트엔드 라우트 ========== */
                     .requestMatchers(
+                        "/login",
                         "/profiles/**",
                         "/playlists/**",
                         "/contents/**",

--- a/mopl-api/src/main/java/io/mopl/api/common/config/SecurityConfig.java
+++ b/mopl-api/src/main/java/io/mopl/api/common/config/SecurityConfig.java
@@ -144,8 +144,6 @@ public class SecurityConfig {
 
                     /* ========== 인증 관리 ========== */
                     // 전체: 모든 기능
-                    .requestMatchers(HttpMethod.GET, "/api/auth/refresh")
-                    .permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/auth/sign-in", "/api/auth/refresh")
                     .permitAll()
                     .requestMatchers("/api/auth/**")


### PR DESCRIPTION
## 📌 작업 개요
- 작업 내용: SecurityConfig에서 GET 메서드의 refresh 허용 제거
- 관련 이슈: #이슈번호

## 🚀 주요 변경 사항
- [x] SecurityConfig에서 GET 메서드의 refresh 허용 제거
- [ ] (변경 사항 2)

## 🛠 DB 변경 사항
- [ ] MySQL 스키마 변경 여부 (DDL 첨부)
- [ ] Redis 키 구조 변경 여부

## 🧪 테스트 결과 (필수)
> 팀 가이드에 따라 Postman/local 환경에서의 기능 테스트를 완료해야 합니다.

- [ ] **테스트 수행 완료**
- **테스트 시나리오:** (예: 이메일 중복 체크 -> 회원가입 성공 -> 로그인 확인)
- **증빙자료:** (Postman 응답 결과 캡쳐본 첨부 또는 JSON 응답 복사)

## ✅ 체크리스트
- [x] 코드 컨벤션(Checkstyle/Spotless)을 준수했는가?
- [x] 빌드가 성공적으로 수행되는가? (`./gradlew build`)
- [x] 불필요한 주석이나 print문은 제거했는가?