### PR TITLE
feat: 플레이리스트 조회 2번째 성능 개선

### DIFF
--- a/mopl-api/src/main/java/io/mopl/api/playlist/domain/PlaylistQueryRepositoryImpl.java
+++ b/mopl-api/src/main/java/io/mopl/api/playlist/domain/PlaylistQueryRepositoryImpl.java
@@ -24,12 +24,12 @@ public class PlaylistQueryRepositoryImpl implements PlaylistQueryRepository {
 
   @Override
   public PlaylistPage findPlaylistsPage(PlaylistSearchRequest request) {
-    // 기본 페이징/정렬 값
+    // 기본 페이지 정렬 값
     int limit = request.getLimitOrDefault();
     String sortByRaw = request.getSortByOrDefault();
     String sortDirectionRaw = request.getSortDirectionOrDefault();
 
-    // 내부 enum 변환
+    // 정렬 enum 변환
     SortBy sortBy = SortBy.from(sortByRaw);
     SortDirection sortDirection = SortDirection.from(sortDirectionRaw);
 
@@ -97,14 +97,14 @@ public class PlaylistQueryRepositoryImpl implements PlaylistQueryRepository {
     return count != null ? count.longValue() : 0L;
   }
 
-  // 기본 필터 구성 shared by list/count.
+  // 기본 필터 구성 (list/count 공통)
   private BooleanBuilder buildBaseWhere(
       String keywordLike, UUID ownerIdEqual, UUID subscriberIdEqual, QPlaylist p) {
     BooleanBuilder where = new BooleanBuilder();
 
-    // 제목 검색 (대소문자 무시)
+    // 제목 검색(prefix)
     if (keywordLike != null && !keywordLike.isBlank()) {
-      where.and(p.title.containsIgnoreCase(keywordLike));
+      where.and(p.title.startsWithIgnoreCase(keywordLike));
     }
 
     // 소유자 필터

--- a/mopl-api/src/main/java/io/mopl/api/playlist/dto/PlaylistSearchRequest.java
+++ b/mopl-api/src/main/java/io/mopl/api/playlist/dto/PlaylistSearchRequest.java
@@ -18,6 +18,7 @@ public class PlaylistSearchRequest {
   private UUID subscriberIdEqual;
   private String cursor;
   private UUID idAfter;
+  private Boolean includeTotalCount;
 
   @Min(1)
   @Max(100)
@@ -43,6 +44,10 @@ public class PlaylistSearchRequest {
 
   public String getSortByOrDefault() {
     return (sortBy == null || sortBy.isBlank()) ? "updatedAt" : sortBy;
+  }
+
+  public boolean getIncludeTotalCountOrDefault() {
+    return includeTotalCount == null || includeTotalCount;
   }
 
   @AssertTrue(message = "cursor and idAfter must be provided together")

--- a/mopl-api/src/main/java/io/mopl/api/playlist/service/PlaylistQueryService.java
+++ b/mopl-api/src/main/java/io/mopl/api/playlist/service/PlaylistQueryService.java
@@ -61,7 +61,7 @@ public class PlaylistQueryService {
     PlaylistPage page = playlistQueryRepository.findPlaylistsPage(request);
 
     // 동일 필터 조건으로 totalCount 계산(캐시 포함)
-    long totalCount = getTotalCount(request);
+    long totalCount = request.getIncludeTotalCountOrDefault() ? getTotalCount(request) : -1L;
 
     List<Playlist> playlists = page.getPlaylists();
 

--- a/mopl-api/src/main/java/io/mopl/api/playlist/service/loader/PlaylistContentLoader.java
+++ b/mopl-api/src/main/java/io/mopl/api/playlist/service/loader/PlaylistContentLoader.java
@@ -82,18 +82,8 @@ public class PlaylistContentLoader {
 
     List<Tuple> rows =
         queryFactory
-            .select(
-                pc.id.playlistId,
-                pc.id.contentId,
-                c.type,
-                c.title,
-                c.description,
-                c.thumbnailImageKey,
-                c.averageRating,
-                c.reviewCount)
+            .select(pc.id.playlistId, pc.id.contentId)
             .from(pc)
-            .join(c)
-            .on(pc.id.contentId.eq(c.id))
             .where(
                 pc.id
                     .playlistId
@@ -107,7 +97,6 @@ public class PlaylistContentLoader {
             .fetch();
 
     Map<UUID, UUID> thumbnailContentIdByPlaylistId = new HashMap<>();
-    Map<UUID, ContentBase> baseByContentId = new HashMap<>();
     Set<UUID> allContentIds = new HashSet<>();
 
     for (Tuple row : rows) {
@@ -119,7 +108,33 @@ public class PlaylistContentLoader {
       UUID contentId = row.get(pc.id.contentId);
       thumbnailContentIdByPlaylistId.put(playlistId, contentId);
       allContentIds.add(contentId);
+    }
 
+    if (allContentIds.isEmpty()) {
+      for (UUID playlistId : missIds) {
+        result.putIfAbsent(playlistId, List.of());
+      }
+      cacheContents(result, missIds, RedisKeyPrefix.PLAYLIST_THUMBNAIL_CONTENT);
+      return result;
+    }
+
+    List<Tuple> contentRows =
+        queryFactory
+            .select(
+                c.id,
+                c.type,
+                c.title,
+                c.description,
+                c.thumbnailImageKey,
+                c.averageRating,
+                c.reviewCount)
+            .from(c)
+            .where(c.id.in(allContentIds))
+            .fetch();
+
+    Map<UUID, ContentBase> baseByContentId = new HashMap<>();
+    for (Tuple row : contentRows) {
+      UUID contentId = row.get(c.id);
       Double avg = row.get(c.averageRating);
       double avgValue = avg != null ? avg.doubleValue() : 0.0d;
       Integer reviewCount = row.get(c.reviewCount);
@@ -134,14 +149,6 @@ public class PlaylistContentLoader {
               avgValue,
               reviewCount != null ? reviewCount.intValue() : 0);
       baseByContentId.put(contentId, base);
-    }
-
-    if (allContentIds.isEmpty()) {
-      for (UUID playlistId : missIds) {
-        result.putIfAbsent(playlistId, List.of());
-      }
-      cacheContents(result, missIds, RedisKeyPrefix.PLAYLIST_THUMBNAIL_CONTENT);
-      return result;
     }
 
     QContentTag ct = QContentTag.contentTag;

--- a/mopl-api/src/main/java/io/mopl/api/playlist/service/loader/PlaylistSubscriptionLoader.java
+++ b/mopl-api/src/main/java/io/mopl/api/playlist/service/loader/PlaylistSubscriptionLoader.java
@@ -35,7 +35,8 @@ public class PlaylistSubscriptionLoader {
 
     // Redis set이 있으면 캐시로 구독 여부 확인
     try {
-      if (Boolean.TRUE.equals(redisTemplate.hasKey(key))) {
+      Boolean keyExists = redisTemplate.hasKey(key);
+      if (Boolean.TRUE.equals(keyExists)) {
         @SuppressWarnings("unchecked")
         RedisSerializer<String> serializer =
             (RedisSerializer<String>) redisTemplate.getStringSerializer();
@@ -64,7 +65,12 @@ public class PlaylistSubscriptionLoader {
             result.add(playlistIds.get(i));
           }
         }
-        return result;
+        // 키가 있었는데 결과가 비어있으면 만료/삭제 경합 가능성 → DB 조회로 대체
+        if (result.isEmpty() && !playlistIds.isEmpty()) {
+          log.debug("Redis 키는 존재했으나 결과가 비어있어 DB 조회로 대체 key={}", key);
+        } else {
+          return result;
+        }
       }
     } catch (Exception e) {
       log.warn("Redis 캐시 조회 실패 key={} error={}", key, e.getMessage());

--- a/mopl-api/src/main/java/io/mopl/api/playlist/service/loader/PlaylistSubscriptionLoader.java
+++ b/mopl-api/src/main/java/io/mopl/api/playlist/service/loader/PlaylistSubscriptionLoader.java
@@ -33,7 +33,7 @@ public class PlaylistSubscriptionLoader {
     String key = RedisKeyPrefix.PLAYLIST_SUBS_BY_USER + me;
     Set<UUID> result = new HashSet<>();
 
-    // Redis set??鈺곕똻???롢늺 筌?Ŋ??癒?퐣 ?닌됰즴 ??????類ㅼ뵥
+    // Redis set이 있으면 캐시로 구독 여부 확인
     try {
       if (Boolean.TRUE.equals(redisTemplate.hasKey(key))) {
         @SuppressWarnings("unchecked")

--- a/mopl-api/src/main/java/io/mopl/api/playlist/service/loader/PlaylistSubscriptionLoader.java
+++ b/mopl-api/src/main/java/io/mopl/api/playlist/service/loader/PlaylistSubscriptionLoader.java
@@ -3,7 +3,6 @@ package io.mopl.api.playlist.service.loader;
 import io.mopl.api.playlist.domain.PlaylistSubscription;
 import io.mopl.api.playlist.domain.PlaylistSubscriptionRepository;
 import io.mopl.redis.constants.RedisKeyPrefix;
-import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -34,7 +33,7 @@ public class PlaylistSubscriptionLoader {
     String key = RedisKeyPrefix.PLAYLIST_SUBS_BY_USER + me;
     Set<UUID> result = new HashSet<>();
 
-    // Redis set이 존재하면 캐시에서 구독 여부를 확인
+    // Redis set??鈺곕똻???롢늺 筌?Ŋ??癒?퐣 ?닌됰즴 ??????類ㅼ뵥
     try {
       if (Boolean.TRUE.equals(redisTemplate.hasKey(key))) {
         @SuppressWarnings("unchecked")
@@ -69,32 +68,14 @@ public class PlaylistSubscriptionLoader {
       }
     } catch (Exception e) {
       log.warn("Redis 캐시 조회 실패 key={} error={}", key, e.getMessage());
-      // fallback to DB query below
+      // Redis 장애 시 DB 조회로 대체
     }
 
-    // 캐시가 없으면 사용자가 구독한 전체 플레이리스트를 DB에서 조회
-    List<PlaylistSubscription> allSubs = subscriptionRepository.findByIdUserId(me);
-    Set<UUID> allSubscribedIds = new HashSet<>();
-    for (PlaylistSubscription sub : allSubs) {
-      allSubscribedIds.add(sub.getId().getPlaylistId());
-    }
-
-    // 전체 구독 목록을 Redis에 저장
-    if (!allSubscribedIds.isEmpty()) {
-      try {
-        String[] values = allSubscribedIds.stream().map(UUID::toString).toArray(String[]::new);
-        redisTemplate.opsForSet().add(key, values);
-        redisTemplate.expire(key, Duration.ofHours(6));
-      } catch (Exception e) {
-        log.warn("Redis 캐시 저장 실패 key={} error={}", key, e.getMessage());
-      }
-    }
-
-    // 요청한 playlistIds 중 구독된 것만 반환
-    for (UUID playlistId : playlistIds) {
-      if (allSubscribedIds.contains(playlistId)) {
-        result.add(playlistId);
-      }
+    // 캐시가 없으면 요청된 playlistIds만 DB 조회
+    List<PlaylistSubscription> subs =
+        subscriptionRepository.findByIdUserIdAndIdPlaylistIdIn(me, playlistIds);
+    for (PlaylistSubscription sub : subs) {
+      result.add(sub.getId().getPlaylistId());
     }
 
     return result;


### PR DESCRIPTION
## 📌 작업 개요
- 작업 내용: 플레이리스트 조회 2번째 성능 개선
- 관련 이슈: #이슈번호

## 🚀 주요 변경 사항
- totalCount를 옵션화
- 구독 조회 cache miss fallback을 좁히기
- 썸네일 콘텐츠 사전 계산/컬럼 캐싱
- 키워드 검색 개선

## 🛠 DB 변경 사항
- [ ] MySQL 스키마 변경 여부 (DDL 첨부)
- [ ] Redis 키 구조 변경 여부

## 🧪 테스트 결과 (필수)
> 팀 가이드에 따라 Postman/local 환경에서의 기능 테스트를 완료해야 합니다.

- [ ] **테스트 수행 완료**
- **테스트 시나리오:** (예: 이메일 중복 체크 -> 회원가입 성공 -> 로그인 확인)
- **증빙자료:** (Postman 응답 결과 캡쳐본 첨부 또는 JSON 응답 복사)

## ✅ 체크리스트
- [x] 코드 컨벤션(Checkstyle/Spotless)을 준수했는가?
- [x] 빌드가 성공적으로 수행되는가? (`./gradlew build`)
- [x] 불필요한 주석이나 print문은 제거했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 플레이리스트 검색에서 결과 총개수 포함 여부를 요청별로 제어할 수 있습니다.

* **개선사항**
  * 검색이 제목의 앞부분 일치로 동작하도록 변경되어 더 일관된 결과를 제공합니다.
  * 콘텐츠 로드 흐름이 개선되어 불필요한 조회를 줄이고 성능/응답성이 향상되었습니다.
  * 구독 조회 로직이 간소화되어 캐시 실패 시 안전하게 DB로 폴백하며 불필요한 캐시 쓰기를 줄입니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->