### PR TITLE
fix: OAuth2 인증 요청을 쿠키 기반으로 저장하도록 수정

### DIFF
--- a/mopl-api/src/main/java/io/mopl/api/auth/dto/OAuth2AuthorizationRequestDto.java
+++ b/mopl-api/src/main/java/io/mopl/api/auth/dto/OAuth2AuthorizationRequestDto.java
@@ -1,0 +1,104 @@
+package io.mopl.api.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serializable;
+import java.util.Map;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OAuth2AuthorizationRequestDto implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  @JsonProperty("authorizationUri")
+  private String authorizationUri;
+
+  @JsonProperty("authorizationGrantType")
+  private String authorizationGrantType;
+
+  @JsonProperty("responseType")
+  private String responseType;
+
+  @JsonProperty("clientId")
+  private String clientId;
+
+  @JsonProperty("redirectUri")
+  private String redirectUri;
+
+  @JsonProperty("scopes")
+  private Set<String> scopes;
+
+  @JsonProperty("state")
+  private String state;
+
+  @JsonProperty("additionalParameters")
+  private Map<String, Object> additionalParameters;
+
+  @JsonProperty("authorizationRequestUri")
+  private String authorizationRequestUri;
+
+  @JsonProperty("attributes")
+  private Map<String, Object> attributes;
+
+  /** OAuth2AuthorizationRequest를 DTO로 변환 */
+  public static OAuth2AuthorizationRequestDto from(OAuth2AuthorizationRequest request) {
+    if (request == null) {
+      return null;
+    }
+
+    return OAuth2AuthorizationRequestDto.builder()
+        .authorizationUri(request.getAuthorizationUri())
+        .authorizationGrantType(
+            request.getGrantType() != null ? request.getGrantType().getValue() : null)
+        .responseType(
+            request.getResponseType() != null ? request.getResponseType().getValue() : null)
+        .clientId(request.getClientId())
+        .redirectUri(request.getRedirectUri())
+        .scopes(request.getScopes())
+        .state(request.getState())
+        .additionalParameters(request.getAdditionalParameters())
+        .authorizationRequestUri(request.getAuthorizationRequestUri())
+        .attributes(request.getAttributes())
+        .build();
+  }
+
+  /** DTO를 OAuth2AuthorizationRequest로 변환 */
+  public OAuth2AuthorizationRequest toOAuth2AuthorizationRequest() {
+    OAuth2AuthorizationRequest.Builder builder =
+        OAuth2AuthorizationRequest.authorizationCode()
+            .authorizationUri(this.authorizationUri)
+            .clientId(this.clientId)
+            .redirectUri(this.redirectUri)
+            .state(this.state);
+
+    // scopes 설정
+    if (this.scopes != null && !this.scopes.isEmpty()) {
+      builder.scopes(this.scopes);
+    }
+
+    // additionalParameters 설정
+    if (this.additionalParameters != null && !this.additionalParameters.isEmpty()) {
+      builder.additionalParameters(this.additionalParameters);
+    }
+
+    // attributes 설정
+    if (this.attributes != null && !this.attributes.isEmpty()) {
+      builder.attributes(this.attributes);
+    }
+
+    // authorizationRequestUri 설정
+    if (this.authorizationRequestUri != null) {
+      builder.authorizationRequestUri(this.authorizationRequestUri);
+    }
+
+    return builder.build();
+  }
+}

--- a/mopl-api/src/main/java/io/mopl/api/auth/oauth2/CookieOAuth2AuthorizationRequestRepository.java
+++ b/mopl-api/src/main/java/io/mopl/api/auth/oauth2/CookieOAuth2AuthorizationRequestRepository.java
@@ -1,0 +1,82 @@
+package io.mopl.api.auth.oauth2;
+
+import com.nimbusds.oauth2.sdk.util.StringUtils;
+import io.mopl.api.common.util.CookieUtils;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CookieOAuth2AuthorizationRequestRepository
+    implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+  public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+  public static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
+  private static final int COOKIE_EXPIRE_SECONDS = 180; // 3분
+
+  private final CookieUtils cookieUtils;
+
+  @Override
+  public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+    return cookieUtils
+        .getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+        .map(cookie -> cookieUtils.deserialize(cookie, OAuth2AuthorizationRequest.class))
+        .orElse(null);
+  }
+
+  @Override
+  public void saveAuthorizationRequest(
+      OAuth2AuthorizationRequest authorizationRequest,
+      HttpServletRequest request,
+      HttpServletResponse response) {
+
+    if (authorizationRequest == null) {
+      cookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+      cookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+      return;
+    }
+
+    log.debug("OAuth2 Authorization Request 저장: state={}", authorizationRequest.getState());
+
+    // Authorization Request를 쿠키에 저장
+    cookieUtils.addCookie(
+        response,
+        OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME,
+        cookieUtils.serialize(authorizationRequest),
+        COOKIE_EXPIRE_SECONDS);
+
+    // Redirect URI를 쿠키에 저장 (필요시)
+    String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
+    if (StringUtils.isNotBlank(redirectUriAfterLogin)) {
+      cookieUtils.addCookie(
+          response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin, COOKIE_EXPIRE_SECONDS);
+    }
+  }
+
+  @Override
+  public OAuth2AuthorizationRequest removeAuthorizationRequest(
+      HttpServletRequest request, HttpServletResponse response) {
+    log.debug("OAuth2 Authorization Request 제거");
+    OAuth2AuthorizationRequest authorizationRequest = this.loadAuthorizationRequest(request);
+
+    if (authorizationRequest != null) {
+      cookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+      cookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+    }
+
+    return authorizationRequest;
+  }
+
+  /** Authorization Request 쿠키 삭제 */
+  public void removeAuthorizationRequestCookies(
+      HttpServletRequest request, HttpServletResponse response) {
+    cookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+    cookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+  }
+}

--- a/mopl-api/src/main/java/io/mopl/api/auth/oauth2/CookieOAuth2AuthorizationRequestRepository.java
+++ b/mopl-api/src/main/java/io/mopl/api/auth/oauth2/CookieOAuth2AuthorizationRequestRepository.java
@@ -1,6 +1,7 @@
 package io.mopl.api.auth.oauth2;
 
 import com.nimbusds.oauth2.sdk.util.StringUtils;
+import io.mopl.api.auth.dto.OAuth2AuthorizationRequestDto;
 import io.mopl.api.common.util.CookieUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -26,7 +27,18 @@ public class CookieOAuth2AuthorizationRequestRepository
   public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
     return cookieUtils
         .getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
-        .map(cookie -> cookieUtils.deserialize(cookie, OAuth2AuthorizationRequest.class))
+        .map(
+            cookie -> {
+              OAuth2AuthorizationRequestDto dto =
+                  cookieUtils.deserialize(cookie, OAuth2AuthorizationRequestDto.class);
+
+              if (dto != null) {
+                return dto.toOAuth2AuthorizationRequest();
+              }
+
+              log.warn("OAuth2 Authorization Request DTO 역직렬화 실패");
+              return null;
+            })
         .orElse(null);
   }
 
@@ -44,14 +56,20 @@ public class CookieOAuth2AuthorizationRequestRepository
 
     log.debug("OAuth2 Authorization Request 저장: state={}", authorizationRequest.getState());
 
-    // Authorization Request를 쿠키에 저장
-    cookieUtils.addCookie(
-        response,
-        OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME,
-        cookieUtils.serialize(authorizationRequest),
-        COOKIE_EXPIRE_SECONDS);
+    try {
+      OAuth2AuthorizationRequestDto dto = OAuth2AuthorizationRequestDto.from(authorizationRequest);
 
-    // Redirect URI를 쿠키에 저장 (필요시)
+      cookieUtils.addCookie(
+          response,
+          OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME,
+          cookieUtils.serialize(dto),
+          COOKIE_EXPIRE_SECONDS);
+    } catch (Exception e) {
+      log.error("OAuth2 Authorization Request 저장 실패", e);
+      cookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+      throw new IllegalStateException("OAuth2 인증 요청 저장에 실패했습니다", e);
+    }
+
     String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
     if (StringUtils.isNotBlank(redirectUriAfterLogin)) {
       cookieUtils.addCookie(

--- a/mopl-api/src/main/java/io/mopl/api/common/config/SecurityConfig.java
+++ b/mopl-api/src/main/java/io/mopl/api/common/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package io.mopl.api.common.config;
 
 import io.mopl.api.auth.jwt.JwtAuthenticationFilter;
+import io.mopl.api.auth.oauth2.CookieOAuth2AuthorizationRequestRepository;
 import io.mopl.api.auth.oauth2.CustomOAuth2AuthorizationRequestResolver;
 import io.mopl.api.auth.oauth2.OAuth2AuthenticationFailureHandler;
 import io.mopl.api.auth.oauth2.OAuth2AuthenticationSuccessHandler;
@@ -39,6 +40,8 @@ public class SecurityConfig {
   private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
   private final OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
   private final CustomOAuth2AuthorizationRequestResolver customOAuth2AuthorizationRequestResolver;
+  private final CookieOAuth2AuthorizationRequestRepository
+      cookieOAuth2AuthorizationRequestRepository;
   private final MessageSource messageSource;
   private final ObjectMapper objectMapper;
 
@@ -261,7 +264,9 @@ public class SecurityConfig {
                             authorization
                                 .baseUri("/oauth2/authorization")
                                 .authorizationRequestResolver(
-                                    customOAuth2AuthorizationRequestResolver))
+                                    customOAuth2AuthorizationRequestResolver)
+                                .authorizationRequestRepository(
+                                    cookieOAuth2AuthorizationRequestRepository))
                     .redirectionEndpoint(redirection -> redirection.baseUri("/login/oauth2/code/*"))
                     .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
                     .successHandler(oAuth2AuthenticationSuccessHandler)

--- a/mopl-api/src/main/java/io/mopl/api/common/util/CookieUtils.java
+++ b/mopl-api/src/main/java/io/mopl/api/common/util/CookieUtils.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.util.SerializationUtils;
+import tools.jackson.databind.ObjectMapper;
 
 @Slf4j
 @Component
@@ -19,6 +19,7 @@ public class CookieUtils {
 
   private final CookieSecurityProperties cookieSecurityProperties;
   private final JwtTokenProvider jwtTokenProvider;
+  private final ObjectMapper objectMapper;
 
   /** Refresh Token 쿠키 설정 */
   public void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
@@ -88,6 +89,11 @@ public class CookieUtils {
           cookie.setValue("");
           cookie.setPath("/");
           cookie.setMaxAge(0);
+          cookie.setSecure(cookieSecurityProperties.isSecure());
+          String sameSite = cookieSecurityProperties.getSameSite();
+          if (sameSite != null && !sameSite.isEmpty()) {
+            cookie.setAttribute("SameSite", sameSite);
+          }
           response.addCookie(cookie);
         }
       }
@@ -96,14 +102,19 @@ public class CookieUtils {
 
   /** 객체를 Base64 문자열로 직렬화 */
   public String serialize(Object object) {
-    return Base64.getUrlEncoder().encodeToString(SerializationUtils.serialize(object));
+    try {
+      return Base64.getUrlEncoder().encodeToString(objectMapper.writeValueAsBytes(object));
+    } catch (Exception e) {
+      log.error("직렬화 실패", e);
+      throw new IllegalArgumentException("직렬화 실패", e);
+    }
   }
 
   /** Base64 문자열을 객체로 역직렬화 */
   public <T> T deserialize(Cookie cookie, Class<T> cls) {
     try {
       byte[] decodedBytes = Base64.getUrlDecoder().decode(cookie.getValue());
-      return cls.cast(SerializationUtils.deserialize(decodedBytes));
+      return objectMapper.readValue(decodedBytes, cls);
     } catch (Exception e) {
       log.error("쿠키 역직렬화 실패: {}", cookie.getName(), e);
       return null;

--- a/mopl-api/src/main/java/io/mopl/api/common/util/CookieUtils.java
+++ b/mopl-api/src/main/java/io/mopl/api/common/util/CookieUtils.java
@@ -3,10 +3,16 @@ package io.mopl.api.common.util;
 import io.mopl.api.auth.jwt.JwtTokenProvider;
 import io.mopl.api.common.config.CookieSecurityProperties;
 import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Base64;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.util.SerializationUtils;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class CookieUtils {
@@ -38,5 +44,69 @@ public class CookieUtils {
     cookie.setAttribute("SameSite", cookieSecurityProperties.getSameSite());
 
     response.addCookie(cookie);
+  }
+
+  /** 요청에서 특정 이름의 쿠키를 가져옴 */
+  public Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+    Cookie[] cookies = request.getCookies();
+
+    if (cookies != null && cookies.length > 0) {
+      for (Cookie cookie : cookies) {
+        if (name.equals(cookie.getName())) {
+          return Optional.of(cookie);
+        }
+      }
+    }
+
+    return Optional.empty();
+  }
+
+  /** 응답에 쿠키 추가 */
+  public void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+    Cookie cookie = new Cookie(name, value);
+    cookie.setPath("/");
+    cookie.setHttpOnly(false);
+    cookie.setSecure(cookieSecurityProperties.isSecure());
+    cookie.setMaxAge(maxAge);
+
+    // SameSite 속성 설정
+    String sameSite = cookieSecurityProperties.getSameSite();
+    if (sameSite != null && !sameSite.isEmpty()) {
+      cookie.setAttribute("SameSite", sameSite);
+    }
+
+    response.addCookie(cookie);
+  }
+
+  /** 쿠키 삭제 */
+  public void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+    Cookie[] cookies = request.getCookies();
+
+    if (cookies != null && cookies.length > 0) {
+      for (Cookie cookie : cookies) {
+        if (name.equals(cookie.getName())) {
+          cookie.setValue("");
+          cookie.setPath("/");
+          cookie.setMaxAge(0);
+          response.addCookie(cookie);
+        }
+      }
+    }
+  }
+
+  /** 객체를 Base64 문자열로 직렬화 */
+  public String serialize(Object object) {
+    return Base64.getUrlEncoder().encodeToString(SerializationUtils.serialize(object));
+  }
+
+  /** Base64 문자열을 객체로 역직렬화 */
+  public <T> T deserialize(Cookie cookie, Class<T> cls) {
+    try {
+      byte[] decodedBytes = Base64.getUrlDecoder().decode(cookie.getValue());
+      return cls.cast(SerializationUtils.deserialize(decodedBytes));
+    } catch (Exception e) {
+      log.error("쿠키 역직렬화 실패: {}", cookie.getName(), e);
+      return null;
+    }
   }
 }


### PR DESCRIPTION
## 📌 작업 개요
- 작업 내용: OAuth2 인증 요청을 쿠키 기반으로 저장하도록 수정
- 관련 이슈: #이슈번호

## 🚀 주요 변경 사항
- [x] OAuth2 인증 요청을 쿠키 기반으로 저장하도록 수정
- [ ] (변경 사항 2)

## 🛠 DB 변경 사항
- [ ] MySQL 스키마 변경 여부 (DDL 첨부)
- [ ] Redis 키 구조 변경 여부

## 🧪 테스트 결과 (필수)
> 팀 가이드에 따라 Postman/local 환경에서의 기능 테스트를 완료해야 합니다.

- [ ] **테스트 수행 완료**
- **테스트 시나리오:** (예: 이메일 중복 체크 -> 회원가입 성공 -> 로그인 확인)
- **증빙자료:** (Postman 응답 결과 캡쳐본 첨부 또는 JSON 응답 복사)

## ✅ 체크리스트
- [x] 코드 컨벤션(Checkstyle/Spotless)을 준수했는가?
- [x] 빌드가 성공적으로 수행되는가? (`./gradlew build`)
- [x] 불필요한 주석이나 print문은 제거했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * OAuth2 인증 상태를 쿠키에 안전하게 저장·복원하도록 도입
  * 인증 리디렉션 주소를 선택적으로 쿠키에 보존하여 로그인 흐름 개선
* **버그 수정 / 안정성**
  * 쿠키 직렬화/역직렬화 및 삭제 처리 강화로 인증 실패·누락 감소
  * 로그인 플로우에 쿠키 기반 저장소 통합으로 일관성 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->