### PR TITLE
fix: Kafka Listener에 MANUAL ack 컨테이너를 지정해서 Acknowledgement가 정상 주입되도록 변경

### DIFF
--- a/mopl-worker/src/main/java/io/mopl/worker/content/index/ContentIndexKafkaListener.java
+++ b/mopl-worker/src/main/java/io/mopl/worker/content/index/ContentIndexKafkaListener.java
@@ -37,7 +37,8 @@ public class ContentIndexKafkaListener {
   @KafkaListener(
       topics = KafkaTopics.CONTENT_INDEX_REQUESTED,
       properties =
-          "spring.json.value.default.type=io.mopl.core.event.content.ContentIndexBatchRequestedEvent")
+          "spring.json.value.default.type=io.mopl.core.event.content.ContentIndexBatchRequestedEvent",
+      containerFactory = "manualAckKafkaListenerContainerFactory")
   public void handle(ContentIndexBatchRequestedEvent event, Acknowledgment acknowledgment) {
     if (event.contentIds() == null || event.contentIds().isEmpty()) {
       acknowledgment.acknowledge();


### PR DESCRIPTION
## 📌 작업 개요
- 작업 내용: Kafka Listener에 MANUAL ack 컨테이너를 지정해서 Acknowledgement가 정상 주입되도록 변경
- 관련 이슈: 

## 🚀 주요 변경 사항
- [x] Kafka Listener에 MANUAL ack 컨테이너를 지정해서 Acknowledgement가 정상 주입되도록 변경: 로컬에서는 동작하지만 배포환경에서는 다음과 같은 에러가 발생. -> 해당 에러 수정을 위해 정의되어 있는 manualAckKafkaListenerContainerFactory를 KafkaListener와 연결

```
<html>
<body>
<!--StartFragment-->
2026년 1월 28일, 18:36 | at org.springframework.kafka.listener.KafkaMessageListenerContainer$ListenerConsumer.invokeIfHaveRecords(KafkaMessageListenerContainer.java:1538) ~[spring-kafka-4.0.1.jar!/:4.0.1] | mopl-worker-container
-- | -- | --
2026년 1월 28일, 18:36 | at org.springframework.kafka.listener.KafkaMessageListenerContainer$ListenerConsumer.pollAndInvoke(KafkaMessageListenerContainer.java:1476) ~[spring-kafka-4.0.1.jar!/:4.0.1] | mopl-worker-container
2026년 1월 28일, 18:36 | at org.springframework.kafka.listener.KafkaMessageListenerContainer$ListenerConsumer.run(KafkaMessageListenerContainer.java:1345) ~[spring-kafka-4.0.1.jar!/:4.0.1] | mopl-worker-container
2026년 1월 28일, 18:36 | at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(Unknown Source) ~[na:na] | mopl-worker-container
2026년 1월 28일, 18:36 | at java.base/java.lang.Thread.run(Unknown Source) ~[na:na] | mopl-worker-container
2026년 1월 28일, 18:36 | Suppressed: org.springframework.kafka.listener.ListenerExecutionFailedException: Restored Stack Trace | mopl-worker-container
2026년 1월 28일, 18:36 | at org.springframework.kafka.listener.adapter.MessagingMessageListenerAdapter.checkAckArg(MessagingMessageListenerAdapter.java:519) ~[spring-kafka-4.0.1.jar!/:4.0.1] | mopl-worker-container
2026년 1월 28일, 18:36 | at org.springframework.kafka.listener.adapter.MessagingMessageListenerAdapter.invokeHandler(MessagingMessageListenerAdapter.java:496) ~[spring-kafka-4.0.1.jar!/:4.0.1] | mopl-worker-container
2026년 1월 28일, 18:36 | at org.springframework.kafka.listener.adapter.MessagingMessageListenerAdapter.invoke(MessagingMessageListenerAdapter.java:425) ~[spring-kafka-4.0.1.jar!/:4.0.1] | mopl-worker-container
2026년 1월 28일, 18:36 | at org.springframework.kafka.listener.adapter.RecordMessagingMessageListenerAdapter.onMessage(RecordMessagingMessageListenerAdapter.java:92) ~[spring-kafka-4.0.1.jar!/:4.0.1] | mopl-worker-container
2026년 1월 28일, 18:36 | at org.springframework.kafka.listener.adapter.RecordMessagingMessageListenerAdapter.onMessage(RecordMessagingMessageListenerAdapter.java:52) ~[spring-kafka-4.0.1.jar!/:4.0.1] | mopl-worker-container
2026년 1월 28일, 18:36 | at org.springframework.kafka.listener.KafkaMessageListenerContainer$ListenerConsumer.doInvokeOnMessage(KafkaMessageListenerContainer.java:2898) ~[spring-kafka-4.0.1.jar!/:4.0.1] | mopl-worker-container
2026년 1월 28일, 18:36 | Caused by: java.lang.IllegalStateException: No Acknowledgment available as an argument, the listener container must have a MANUAL AckMode to populate the Acknowledgment. | mopl-worker-container
2026년 1월 28일, 18:36 | at org.springframework.kafka.listener.adapter.MessagingMessageListenerAdapter.checkAckArg(MessagingMessageListenerAdapter.java:519) ~[spring-kafka-4.0.1.jar!/:4.0.1] | mopl-worker-container
2026년 1월 28일, 18:36 | at org.springframework.kafka.listener.adapter.MessagingMessageListenerAdapter.invokeHandler(MessagingMessageListenerAdapter.java:496) ~[spring-kafka-4.0.1.jar!/:4.0.1] | mopl-worker-container
2026년 1월 28일, 18:36 | at org.springframework.kafka.listener.adapter.MessagingMessageListenerAdapter.invoke(MessagingMessageListenerAdapter.java:425) ~[spring-kafka-4.0.1.jar!/:4.0.1] | mopl-worker-container
2026년 1월 28일, 18:36 | at org.springframework.kafka.listener.adapter.RecordMessagingMessageListenerAdapter.onMessage(RecordMessagingMessageListenerAdapter.java:92) ~[spring-kafka-4.0.1.jar!/:4.0.1] | mopl-worker-container
2026년 1월 28일, 18:36 | at org.springframework.kafka.listener.adapter.RecordMessagingMessageListenerAdapter.onMessage(RecordMessagingMessageListenerAdapter.java:52) ~[spring-kafka-4.0.1.jar!/:4.0.1] | mopl-worker-container
2026년 1월 28일, 18:36 | at org.springframework.kafka.listener.KafkaMessageListenerContainer$ListenerConsumer.doInvokeOnMessage(KafkaMessageListenerContainer.java:2898) ~[spring-kafka-4.0.1.jar!/:4.0.1] | mopl-worker-container
2026년 1월 28일, 18:36 | ... 10 common frames omitted | mopl-worker-container
2026년 1월 28일, 18:36 | 2026-01-28T18:36:23.504+09:00 INFO 1 --- [mopl-worker] [ntainer#6-0-C-1] o.a.k.c.c.i.ClassicKafkaConsumer : [Consumer clientId=consumer-mopl-worker-1, groupId=mopl-worker] Seeking to offset 107 for partition content.index.requested-1 | mopl-worker-container
2026년 1월 28일, 18:36 | 2026-01-28T18:36:23.504+09:00 INFO 1 --- [mopl-worker] [ntainer#6-0-C-1] o.s.k.l.KafkaMessageListenerContainer : Record in retry and not yet recovered | mopl-worker-container
2026년 1월 28일, 18:36 | 2026-01-28T18:36:22.499+09:00 INFO 1 --- [mopl-worker] [ntainer#6-0-C-1] o.a.k.c.c.i.ClassicKafkaConsumer : [Consumer clientId=consumer-mopl-worker-1, groupId=mopl-worker] Seeking to offset 107 for partition content.index.requested-1 | mopl-worker-container
2026년 1월 28일, 18:36 | 2026-01-28T18:36:22.499+09:00 INFO 1 --- [mopl-worker] [ntainer#6-0-C-1] o.s.k.l.KafkaMessageListenerContainer : Record in retry and not yet recovered | mopl-worker-container
2026년 1월 28일, 18:36 | 2026-01-28T18:36:21.491+09:00 INFO 1 --- [mopl-worker] [ntainer#6-0-C-1] o.a.k.c.c.i.ClassicKafkaConsumer : [Consumer clientId=consumer-mopl-worker-1, groupId=mopl-worker] Seeking to offset 107 for partition content.index.requested-1 | mopl-worker-container
2026년 1월 28일, 18:36 | 2026-01-28T18:36:21.491+09:00 INFO 1 --- [mopl-worker] [ntainer#6-0-C-1] o.s.k.l.KafkaMessageListenerContainer : Record in retry and not yet recovered

<!--EndFragment-->
</body>
</html>
```

## 🛠 DB 변경 사항
- [ ] MySQL 스키마 변경 여부 (DDL 첨부)
- [ ] Redis 키 구조 변경 여부

## 🧪 테스트 결과 (필수)
> 팀 가이드에 따라 Postman/local 환경에서의 기능 테스트를 완료해야 합니다.

- [ ] **테스트 수행 완료**
- **테스트 시나리오:** (예: 이메일 중복 체크 -> 회원가입 성공 -> 로그인 확인)
- **증빙자료:** (Postman 응답 결과 캡쳐본 첨부 또는 JSON 응답 복사)

## ✅ 체크리스트
- [ ] 코드 컨벤션(Checkstyle/Spotless)을 준수했는가?
- [ ] 빌드가 성공적으로 수행되는가? (`./gradlew build`)
- [ ] 불필요한 주석이나 print문은 제거했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **버그 수정**
  * 백엔드 메시지 처리의 신뢰성을 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->